### PR TITLE
[3주차] 예매 api 구현 및 동시성 제어를 위한 락 추가

### DIFF
--- a/movie/api/src/main/resources/application.yml
+++ b/movie/api/src/main/resources/application.yml
@@ -46,6 +46,39 @@ spring:
 spring:
   config:
     activate:
+      on-profile: local-redisson
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  jpa:
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+  sql:
+    init:
+      mode: always
+      schema-locations:
+        - classpath:sql/schema-h2.sql
+      data-locations:
+        - classpath:sql/data-h2.sql
+      platform: h2
+      encoding: utf-8
+  data:
+    redis:
+      host: localhost
+      port: 6379
+---
+spring:
+  config:
+    activate:
       on-profile: local-index
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/movie/api/src/main/resources/sql/schema-h2.sql
+++ b/movie/api/src/main/resources/sql/schema-h2.sql
@@ -45,10 +45,12 @@ CREATE TABLE IF NOT EXISTS screening (
     screening_time TIMESTAMP NOT NULL,
     screening_end_time TIMESTAMP NOT NULL,
     status VARCHAR(20) NOT NULL,
+    remaining_seat_count INT DEFAULT 25,
     created_by VARCHAR(50) NOT NULL,
     created_at TIMESTAMP NOT NULL,
     updated_by VARCHAR(50) NOT NULL,
-    updated_at TIMESTAMP NOT NULL
+    updated_at TIMESTAMP NOT NULL,
+    version BIGINT DEFAULT 0
     );
 
 

--- a/movie/api/src/main/resources/sql/schema-mysql-base.sql
+++ b/movie/api/src/main/resources/sql/schema-mysql-base.sql
@@ -45,10 +45,12 @@ CREATE TABLE IF NOT EXISTS screening (
     screening_time TIMESTAMP NOT NULL,
     screening_end_time TIMESTAMP NOT NULL,
     status VARCHAR(20) NOT NULL,
+    remaining_seat_count INT UNSIGNED DEFAULT 25,
     created_by VARCHAR(50) NOT NULL,
     created_at TIMESTAMP NOT NULL,
     updated_by VARCHAR(50) NOT NULL,
-    updated_at TIMESTAMP NOT NULL
+    updated_at TIMESTAMP NOT NULL,
+    version INT UNSIGNED DEFAULT 0
     );
 
 CREATE TABLE IF NOT EXISTS seat (

--- a/movie/api/src/test/kotlin/com/example/movie/controller/MovieControllerTest.kt
+++ b/movie/api/src/test/kotlin/com/example/movie/controller/MovieControllerTest.kt
@@ -84,6 +84,7 @@ class MovieControllerTest {
             screeningTime = screeningTime,
             screeningEndTime = screeningTime.plusMinutes(120),
             status = ScreeningStatus.SCHEDULED,
+            remainingSeatCount = 25,
             createdBy = "test",
             createdAt = currentTime,
             updatedBy = "test",

--- a/movie/api/src/test/kotlin/com/example/movie/controller/ReservationControllerDistributedLockTest.kt
+++ b/movie/api/src/test/kotlin/com/example/movie/controller/ReservationControllerDistributedLockTest.kt
@@ -1,0 +1,103 @@
+package com.example.movie.controller
+
+import com.example.movie.request.ReservationRequest
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.MvcResult
+import org.springframework.test.web.servlet.post
+import java.util.concurrent.Callable
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("local-redisson")
+class ReservationControllerDistributedLockTest(
+    @Autowired val mockMvc: MockMvc,
+    @Autowired val objectMapper: ObjectMapper
+) {
+    @Test
+    fun `Lock을 적용하면 동시 요청시 충돌하면 실패 응답을 한다`() {
+        val latch = CountDownLatch(1)
+        val request1 = ReservationRequest(
+            screeningId = 1,
+            seatIds = listOf(1, 2, 3),
+            userId = 1
+        )
+        val request2 = ReservationRequest(
+            screeningId = 1,
+            seatIds = listOf(1, 2, 3),
+            userId = 2
+        )
+        val requestAnotherScreeningSameSeat = ReservationRequest(
+            screeningId = 9,
+            seatIds = listOf(1, 2, 3),
+            userId = 2
+        )
+        val requestJson1 = objectMapper.writeValueAsString(request1)
+        val requestJson2 = objectMapper.writeValueAsString(request2)
+        val requestJsonAnotherDay = objectMapper.writeValueAsString(requestAnotherScreeningSameSeat)
+
+        val executor = Executors.newFixedThreadPool(3)
+
+        val task1 = Callable {
+            latch.await()
+            mockMvc.post("/api/v1/reservations") {
+                contentType = MediaType.APPLICATION_JSON
+                content = requestJson1
+                accept = MediaType.APPLICATION_JSON
+            }.andReturn()
+        }
+
+        val task2 = Callable {
+            latch.await()
+            mockMvc.post("/api/v1/reservations") {
+                contentType = MediaType.APPLICATION_JSON
+                content = requestJson1
+                accept = MediaType.APPLICATION_JSON
+            }.andReturn()
+        }
+
+        val task3 = Callable {
+            latch.await()
+            mockMvc.post("/api/v1/reservations") {
+                contentType = MediaType.APPLICATION_JSON
+                content = requestJson2
+                accept = MediaType.APPLICATION_JSON
+            }.andReturn()
+        }
+
+        val task4 = Callable {
+            latch.await()
+            mockMvc.post("/api/v1/reservations") {
+                contentType = MediaType.APPLICATION_JSON
+                content = requestJsonAnotherDay
+                accept = MediaType.APPLICATION_JSON
+            }.andReturn()
+        }
+
+        latch.countDown()
+        val futures: List<Future<MvcResult>> = executor.invokeAll(listOf(task1, task2, task3, task4))
+        executor.shutdown()
+
+        val results = futures.map { it.get() }
+        val statuses = results.map { it.response.status }
+
+        println("Thread1 status: ${statuses[0]}, responseBody: ${results[0].response.contentAsString}")
+        println("Thread2 status: ${statuses[1]}, responseBody: ${results[1].response.contentAsString}")
+        println("Thread3 status: ${statuses[2]}, responseBody: ${results[2].response.contentAsString}")
+        println("Thread4 status: ${statuses[3]}, responseBody: ${results[3].response.contentAsString}")
+
+        assertThat(statuses.subList(0, 3)).containsOnlyOnce(200)
+        assertThat(statuses.last()).isEqualTo(200)
+        assertThat(statuses).contains(200, 400)
+    }
+}

--- a/movie/api/src/test/kotlin/com/example/movie/controller/ReservationControllerOptimisticLockTest.kt
+++ b/movie/api/src/test/kotlin/com/example/movie/controller/ReservationControllerOptimisticLockTest.kt
@@ -20,7 +20,7 @@ import java.util.concurrent.Future
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("local")
-class ReservationControllerPessimisticLockTest(
+class ReservationControllerOptimisticLockTest(
     @Autowired val mockMvc: MockMvc,
     @Autowired val objectMapper: ObjectMapper
 ) {

--- a/movie/api/src/test/kotlin/com/example/movie/controller/ReservationControllerPessimisticLockTest.kt
+++ b/movie/api/src/test/kotlin/com/example/movie/controller/ReservationControllerPessimisticLockTest.kt
@@ -1,0 +1,80 @@
+package com.example.movie.controller
+
+import com.example.movie.request.ReservationRequest
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.MvcResult
+import org.springframework.test.web.servlet.post
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("local")
+class ReservationControllerPessimisticLockTest(
+    @Autowired val mockMvc: MockMvc,
+    @Autowired val objectMapper: ObjectMapper
+) {
+    @Test
+    fun `Lock을 적용하면 동시 요청시 충돌하면 실패 응답을 한다`() {
+        val request1 = ReservationRequest(
+            screeningId = 1,
+            seatIds = listOf(1, 2, 3),
+            userId = 1
+        )
+        val request2 = ReservationRequest(
+            screeningId = 1,
+            seatIds = listOf(1, 2, 3),
+            userId = 2
+        )
+        val requestJson1 = objectMapper.writeValueAsString(request1)
+        val requestJson2 = objectMapper.writeValueAsString(request2)
+
+        val executor = Executors.newFixedThreadPool(3)
+
+        val task1 = Callable {
+            mockMvc.post("/api/v1/reservations") {
+                contentType = MediaType.APPLICATION_JSON
+                content = requestJson1
+                accept = MediaType.APPLICATION_JSON
+            }.andReturn()
+        }
+
+        val task2 = Callable {
+            mockMvc.post("/api/v1/reservations") {
+                contentType = MediaType.APPLICATION_JSON
+                content = requestJson1
+                accept = MediaType.APPLICATION_JSON
+            }.andReturn()
+        }
+
+        val task3 = Callable {
+            mockMvc.post("/api/v1/reservations") {
+                contentType = MediaType.APPLICATION_JSON
+                content = requestJson2
+                accept = MediaType.APPLICATION_JSON
+            }.andReturn()
+        }
+
+        val futures: List<Future<MvcResult>> = executor.invokeAll(listOf(task1, task2, task3))
+        executor.shutdown()
+
+        val results = futures.map { it.get() }
+        val statuses = results.map { it.response.status }
+
+        println("Thread1 status: ${statuses[0]}, responseBody: ${results[0].response.contentAsString}")
+        println("Thread2 status: ${statuses[1]}, responseBody: ${results[1].response.contentAsString}")
+        println("Thread3 status: ${statuses[2]}, responseBody: ${results[2].response.contentAsString}")
+
+        assertThat(statuses).containsOnlyOnce(200)
+        assertThat(statuses).contains(200, 400)
+    }
+}

--- a/movie/core/build.gradle
+++ b/movie/core/build.gradle
@@ -8,6 +8,8 @@ plugins {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework:spring-tx'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.43.0'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 bootJar {

--- a/movie/core/src/main/kotlin/com/example/movie/domain/common/model/BaseModel.kt
+++ b/movie/core/src/main/kotlin/com/example/movie/domain/common/model/BaseModel.kt
@@ -5,6 +5,11 @@ import java.time.LocalDateTime
 interface BaseModel {
     val createdBy: String
     val createdAt: LocalDateTime
-    val updatedBy: String
-    val updatedAt: LocalDateTime
+    var updatedBy: String
+    var updatedAt: LocalDateTime
+
+    fun update(updatedBy: String, updateAt: LocalDateTime) {
+        this.updatedBy = updatedBy
+        this.updatedAt = updateAt
+    }
 }

--- a/movie/core/src/main/kotlin/com/example/movie/domain/genre/model/Genre.kt
+++ b/movie/core/src/main/kotlin/com/example/movie/domain/genre/model/Genre.kt
@@ -9,6 +9,6 @@ class Genre(
     val description: String,
     override val createdBy: String,
     override val createdAt: LocalDateTime,
-    override val updatedBy: String,
-    override val updatedAt: LocalDateTime
+    override var updatedBy: String,
+    override var updatedAt: LocalDateTime
 ) : BaseModel

--- a/movie/core/src/main/kotlin/com/example/movie/domain/movie/model/Movie.kt
+++ b/movie/core/src/main/kotlin/com/example/movie/domain/movie/model/Movie.kt
@@ -17,6 +17,6 @@ class Movie(
     val screenings: List<Screening>,
     override val createdBy: String,
     override val createdAt: LocalDateTime,
-    override val updatedBy: String,
-    override val updatedAt: LocalDateTime
+    override var updatedBy: String,
+    override var updatedAt: LocalDateTime
 ) : BaseModel

--- a/movie/core/src/main/kotlin/com/example/movie/domain/reservation/model/Reservation.kt
+++ b/movie/core/src/main/kotlin/com/example/movie/domain/reservation/model/Reservation.kt
@@ -13,7 +13,7 @@ class Reservation(
     val reservationTime: LocalDateTime,
     override val createdBy: String,
     override val createdAt: LocalDateTime,
-    override val updatedBy: String,
-    override val updatedAt: LocalDateTime
+    override var updatedBy: String,
+    override var updatedAt: LocalDateTime
 ) : BaseModel {
 }

--- a/movie/core/src/main/kotlin/com/example/movie/domain/reservation/repository/ReservationRepository.kt
+++ b/movie/core/src/main/kotlin/com/example/movie/domain/reservation/repository/ReservationRepository.kt
@@ -8,4 +8,5 @@ interface ReservationRepository {
     fun findByScreeningAndSeats(screening: Screening, seats: List<Seat>) : List<Reservation>
     fun findByScreeningIdAndUserId(screeningId: Long, userId: Long): List<Reservation>
     fun saveAll(reservations: List<Reservation>): List<Reservation>
+    fun findByScreeningAndSeatsWithLock(screening: Screening, seats: List<Seat>): List<Reservation>
 }

--- a/movie/core/src/main/kotlin/com/example/movie/domain/screening/model/Screening.kt
+++ b/movie/core/src/main/kotlin/com/example/movie/domain/screening/model/Screening.kt
@@ -2,6 +2,7 @@ package com.example.movie.domain.screening.model
 
 import com.example.movie.domain.common.model.BaseModel
 import com.example.movie.domain.movie.model.Movie
+import com.example.movie.domain.reservation.model.Reservation
 import com.example.movie.domain.theater.model.Theater
 import java.time.LocalDateTime
 
@@ -12,8 +13,17 @@ class Screening(
     val screeningTime: LocalDateTime,
     val screeningEndTime: LocalDateTime,
     val status: ScreeningStatus,
+    var remainingSeatCount: Int,
     override val createdBy: String,
     override val createdAt: LocalDateTime,
-    override val updatedBy: String,
-    override val updatedAt: LocalDateTime
-) : BaseModel
+    override var updatedBy: String,
+    override var updatedAt: LocalDateTime,
+) : BaseModel {
+    fun reserveSeats(reservedSeats: List<Reservation>, currentTime: LocalDateTime) {
+        if(remainingSeatCount < reservedSeats.size) {
+            throw IllegalArgumentException("남은 좌석 이상 예매할 수 없습니다")
+        }
+        remainingSeatCount -= reservedSeats.size
+        super.update("user", currentTime)
+    }
+}

--- a/movie/core/src/main/kotlin/com/example/movie/domain/screening/repository/ScreeningRepository.kt
+++ b/movie/core/src/main/kotlin/com/example/movie/domain/screening/repository/ScreeningRepository.kt
@@ -5,4 +5,6 @@ import com.example.movie.domain.screening.model.Screening
 interface ScreeningRepository {
     fun findById(id: Long): Screening?
     fun findByIdWithLock(id: Long): Screening?
+    fun findByIdWithOptimisticLock(id: Long): Screening?
+    fun save(screening: Screening): Screening
 }

--- a/movie/core/src/main/kotlin/com/example/movie/domain/screening/repository/ScreeningRepository.kt
+++ b/movie/core/src/main/kotlin/com/example/movie/domain/screening/repository/ScreeningRepository.kt
@@ -4,4 +4,5 @@ import com.example.movie.domain.screening.model.Screening
 
 interface ScreeningRepository {
     fun findById(id: Long): Screening?
+    fun findByIdWithLock(id: Long): Screening?
 }

--- a/movie/core/src/main/kotlin/com/example/movie/domain/seat/model/Seat.kt
+++ b/movie/core/src/main/kotlin/com/example/movie/domain/seat/model/Seat.kt
@@ -11,6 +11,6 @@ class Seat(
     val col: Int,
     override val createdBy: String,
     override val createdAt: LocalDateTime,
-    override val updatedBy: String,
-    override val updatedAt: LocalDateTime
+    override var updatedBy: String,
+    override var updatedAt: LocalDateTime
 ) : BaseModel

--- a/movie/core/src/main/kotlin/com/example/movie/domain/theater/model/Theater.kt
+++ b/movie/core/src/main/kotlin/com/example/movie/domain/theater/model/Theater.kt
@@ -8,6 +8,6 @@ class Theater(
     val name: String,
     override val createdBy: String,
     override val createdAt: LocalDateTime,
-    override val updatedBy: String,
-    override val updatedAt: LocalDateTime
+    override var updatedBy: String,
+    override var updatedAt: LocalDateTime
 ) : BaseModel

--- a/movie/core/src/main/kotlin/com/example/movie/lock/RedissonClientSetting.kt
+++ b/movie/core/src/main/kotlin/com/example/movie/lock/RedissonClientSetting.kt
@@ -1,0 +1,28 @@
+package com.example.movie.lock
+
+import org.redisson.api.RedissonClient
+import java.util.concurrent.TimeUnit
+
+fun <T> RedissonClient.withLock(
+    lockKey: String,
+    waitTime: Long = 0,
+    leaseTime: Long = 0,
+    block: () -> T
+): T {
+    val lock = this.getLock(lockKey)
+    if (waitTime > 0 && leaseTime > 0) {
+        if (!lock.tryLock(waitTime, leaseTime, TimeUnit.MILLISECONDS)) {
+            throw IllegalStateException("Failed to acquire lock key: $lockKey")
+        }
+    } else {
+        lock.lock()
+    }
+
+    return try {
+        block()
+    } finally {
+        if (lock.isHeldByCurrentThread) {
+            lock.unlock()
+        }
+    }
+}

--- a/movie/core/src/main/kotlin/com/example/movie/lock/aop/DistributedLock.kt
+++ b/movie/core/src/main/kotlin/com/example/movie/lock/aop/DistributedLock.kt
@@ -1,0 +1,9 @@
+package com.example.movie.lock.aop
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class DistributedLock(
+    val key: String,
+    val waitTime: Long,
+    val leaseTime: Long
+)

--- a/movie/core/src/main/kotlin/com/example/movie/lock/aop/DistributedLockAspect.kt
+++ b/movie/core/src/main/kotlin/com/example/movie/lock/aop/DistributedLockAspect.kt
@@ -1,0 +1,46 @@
+package com.example.movie.lock.aop
+
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.reflect.MethodSignature
+import org.redisson.api.RedissonClient
+import org.springframework.expression.spel.standard.SpelExpressionParser
+import org.springframework.expression.spel.support.StandardEvaluationContext
+import org.springframework.stereotype.Component
+import java.util.concurrent.TimeUnit
+
+@Aspect
+@Component
+class DistributedLockAspect(
+    private val redissonClient: RedissonClient
+) {
+
+    @Around("@annotation(distributedLock)")
+    fun aroundDistributedLock(joinPoint: ProceedingJoinPoint, distributedLock: DistributedLock): Any? {
+        val context = StandardEvaluationContext().apply {
+            val paramNames = (joinPoint.signature as MethodSignature).parameterNames
+            joinPoint.args.forEachIndexed { index, arg ->
+                setVariable(paramNames[index], arg)
+            }
+        }
+
+        val parser = SpelExpressionParser()
+        val lockKey = parser.parseExpression(distributedLock.key).getValue(context, String::class.java)
+            ?: throw IllegalArgumentException("Failed to parse distributedLock key")
+
+        val lock = redissonClient.getLock(lockKey)
+
+        return if (lock.tryLock(distributedLock.waitTime, distributedLock.leaseTime, TimeUnit.MILLISECONDS)) {
+            try {
+                joinPoint.proceed()
+            } finally {
+                if (lock.isLocked && lock.isHeldByCurrentThread) {
+                    lock.unlock()
+                }
+            }
+        } else {
+            throw IllegalStateException("Failed to acquire lock key: $lockKey")
+        }
+    }
+}

--- a/movie/core/src/main/kotlin/com/example/movie/service/ReservationFacade.kt
+++ b/movie/core/src/main/kotlin/com/example/movie/service/ReservationFacade.kt
@@ -1,5 +1,6 @@
 package com.example.movie.service
 
+import com.example.movie.lock.aop.DistributedLock
 import com.example.movie.domain.reservation.exception.ReservationException
 import com.example.movie.domain.reservation.model.Reservation
 import org.springframework.dao.OptimisticLockingFailureException
@@ -13,6 +14,7 @@ class ReservationFacade(
         private const val MAX_RETRY_ATTEMPTS = 3
     }
 
+    @DistributedLock(key = "'lock:reservation:' + #screeningId", waitTime = 2000, leaseTime = 1000)
     override fun reserve(userId: Long, screeningId: Long, requestSeatIds: List<Long>): List<Reservation> {
         var retryCount = 0
         while (retryCount < MAX_RETRY_ATTEMPTS) {

--- a/movie/core/src/main/kotlin/com/example/movie/service/ReservationFacade.kt
+++ b/movie/core/src/main/kotlin/com/example/movie/service/ReservationFacade.kt
@@ -1,0 +1,30 @@
+package com.example.movie.service
+
+import com.example.movie.domain.reservation.exception.ReservationException
+import com.example.movie.domain.reservation.model.Reservation
+import org.springframework.dao.OptimisticLockingFailureException
+import org.springframework.stereotype.Service
+
+@Service
+class ReservationFacade(
+    private val reservationService: ReservationService,
+) : ReservationUseCase {
+    companion object {
+        private const val MAX_RETRY_ATTEMPTS = 3
+    }
+
+    override fun reserve(userId: Long, screeningId: Long, requestSeatIds: List<Long>): List<Reservation> {
+        var retryCount = 0
+        while (retryCount < MAX_RETRY_ATTEMPTS) {
+            try {
+                return reservationService.reserve(userId, screeningId, requestSeatIds)
+            } catch (e: OptimisticLockingFailureException) {
+                retryCount++
+                if (retryCount >= MAX_RETRY_ATTEMPTS) {
+                    throw ReservationException("선택할 수 없는 좌석입니다")
+                }
+            }
+        }
+        throw ReservationException("예약 중 오류가 발생했습니다")
+    }
+}

--- a/movie/core/src/main/kotlin/com/example/movie/service/ReservationService.kt
+++ b/movie/core/src/main/kotlin/com/example/movie/service/ReservationService.kt
@@ -26,7 +26,9 @@ class ReservationService(
     override fun reserve(userId: Long, screeningId: Long, requestSeatIds:List<Long>) : List<Reservation> {
         val currentTime = timeHandler.getCurrentTime()
 
-        val screening = screeningRepository.findById(screeningId)
+//        val screening = screeningRepository.findById(screeningId)
+//            ?: throw ReservationException("상영 정보를 찾을 수 없습니다")
+        val screening = screeningRepository.findByIdWithLock(screeningId)
             ?: throw ReservationException("상영 정보를 찾을 수 없습니다")
 
         val movie = movieRepository.findById(screening.movieId)
@@ -42,8 +44,10 @@ class ReservationService(
         val seats = seatRepository.findAllByIdIn(requestSeatIds)
         validateSeats(seats)
 
+//        val reservedSeats = reservationRepository
+//            .findByScreeningAndSeats(screening, seats)
         val reservedSeats = reservationRepository
-            .findByScreeningAndSeats(screening, seats)
+            .findByScreeningAndSeatsWithLock(screening, seats)
         if (reservedSeats.isNotEmpty()) {
             throw ReservationException("이미 예약된 좌석입니다")
         }

--- a/movie/infra/src/main/kotlin/com/example/movie/persistence/common/BaseEntity.kt
+++ b/movie/infra/src/main/kotlin/com/example/movie/persistence/common/BaseEntity.kt
@@ -26,4 +26,9 @@ abstract class BaseEntity {
 
     @LastModifiedDate
     lateinit var updatedAt: LocalDateTime
+
+    fun update(updatedBy: String, updateAt: LocalDateTime) {
+        this.updatedBy = updatedBy
+        this.updatedAt = updatedAt
+    }
 }

--- a/movie/infra/src/main/kotlin/com/example/movie/persistence/movie/dto/QueryDtoMapper.kt
+++ b/movie/infra/src/main/kotlin/com/example/movie/persistence/movie/dto/QueryDtoMapper.kt
@@ -46,6 +46,7 @@ object MovieDtoMapper {
             theater = toTheater(screening),
             screeningTime = screening.screeningTime,
             screeningEndTime = screening.screeningEndTime,
+            remainingSeatCount = -1,
             status = screening.status,
             createdBy = "system",
             createdAt = LocalDateTime.now(),

--- a/movie/infra/src/main/kotlin/com/example/movie/persistence/movie/repository/MovieRepositoryImpl.kt
+++ b/movie/infra/src/main/kotlin/com/example/movie/persistence/movie/repository/MovieRepositoryImpl.kt
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
 
 @Repository
-@Profile("test", "local", "local-index")
+@Profile("test", "local", "local-index", "local-redisson")
 class MovieRepositoryImpl(
     private val movieJpaRepository: MovieJpaRepository,
 ) : MovieRepository {

--- a/movie/infra/src/main/kotlin/com/example/movie/persistence/reservation/repository/ReservationJpaRepository.kt
+++ b/movie/infra/src/main/kotlin/com/example/movie/persistence/reservation/repository/ReservationJpaRepository.kt
@@ -1,7 +1,9 @@
 package com.example.movie.persistence.reservation.repository
 
 import com.example.movie.persistence.reservation.entity.ReservationEntity
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
@@ -10,6 +12,13 @@ import org.springframework.stereotype.Repository
 interface ReservationJpaRepository : JpaRepository<ReservationEntity, Long> {
     @Query("SELECT r FROM ReservationEntity r WHERE r.screening.id = :screeningId AND r.seat.id IN :seatIds")
     fun findByScreeningIdAndSeatIds(
+        @Param("screeningId") screeningId: Long,
+        @Param("seatIds") seatIds: List<Long>
+    ): List<ReservationEntity>
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM ReservationEntity r WHERE r.screening.id = :screeningId AND r.seat.id IN :seatIds")
+    fun findByScreeningIdAndSeatIdsWithLock(
         @Param("screeningId") screeningId: Long,
         @Param("seatIds") seatIds: List<Long>
     ): List<ReservationEntity>

--- a/movie/infra/src/main/kotlin/com/example/movie/persistence/reservation/repository/ReservationRepositoryImpl.kt
+++ b/movie/infra/src/main/kotlin/com/example/movie/persistence/reservation/repository/ReservationRepositoryImpl.kt
@@ -18,6 +18,13 @@ class ReservationRepositoryImpl(
         return reservations.map { it.toDomain() }
     }
 
+    override fun findByScreeningAndSeatsWithLock(screening: Screening, seats: List<Seat>) : List<Reservation> {
+        val reservations = reservationJpaRepository.findByScreeningIdAndSeatIdsWithLock(
+            screeningId = screening.id,
+            seatIds = seats.map { it.id })
+        return reservations.map { it.toDomain() }
+    }
+
     override fun findByScreeningIdAndUserId(screeningId: Long, userId: Long): List<Reservation> {
         return reservationJpaRepository.findByScreeningIdAndUserId(screeningId, userId).map { it.toDomain() }
     }

--- a/movie/infra/src/main/kotlin/com/example/movie/persistence/screening/model/ScreeningEntity.kt
+++ b/movie/infra/src/main/kotlin/com/example/movie/persistence/screening/model/ScreeningEntity.kt
@@ -3,7 +3,6 @@ package com.example.movie.persistence.screening.model
 import com.example.movie.domain.screening.model.Screening
 import com.example.movie.domain.screening.model.ScreeningStatus
 import com.example.movie.persistence.common.BaseEntity
-import com.example.movie.persistence.movie.model.MovieEntity
 import com.example.movie.persistence.theater.entity.TheaterEntity
 import jakarta.persistence.*
 import java.time.LocalDateTime
@@ -27,7 +26,13 @@ class ScreeningEntity(
     val screeningEndTime: LocalDateTime,
 
     @Enumerated(EnumType.STRING)
-    val status: ScreeningStatus,
+    var status: ScreeningStatus,
+
+    @Column(name = "remaining_seat_count")
+    var remainingSeatCount: Int,
+
+    @Version
+    var version: Long = 0,
 ) : BaseEntity() {
     companion object {
         fun from(screening: Screening) = ScreeningEntity(
@@ -37,6 +42,8 @@ class ScreeningEntity(
             screeningTime = screening.screeningTime,
             screeningEndTime = screening.screeningEndTime,
             status = screening.status,
+            remainingSeatCount = screening.remainingSeatCount,
+            version = 0,
         ).apply {
             createdBy = screening.createdBy
             createdAt = screening.createdAt
@@ -53,10 +60,16 @@ class ScreeningEntity(
             screeningTime = screeningTime,
             screeningEndTime = screeningEndTime,
             status = status,
+            remainingSeatCount = remainingSeatCount,
             createdBy = createdBy,
             createdAt = createdAt,
             updatedBy = updatedBy,
-            updatedAt = updatedAt
+            updatedAt = updatedAt,
         )
+    }
+
+    fun updateFromDomain(screening: Screening) {
+        super.update(screening.updatedBy, screening.updatedAt)
+        this.remainingSeatCount = screening.remainingSeatCount
     }
 }

--- a/movie/infra/src/main/kotlin/com/example/movie/persistence/screening/repository/ScreeningJpaRepository.kt
+++ b/movie/infra/src/main/kotlin/com/example/movie/persistence/screening/repository/ScreeningJpaRepository.kt
@@ -1,9 +1,16 @@
 package com.example.movie.persistence.screening.repository
 
 import com.example.movie.persistence.screening.model.ScreeningEntity
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 
 @Repository
 interface ScreeningJpaRepository : JpaRepository<ScreeningEntity, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT s FROM ScreeningEntity s WHERE s.id = :id")
+    fun findByIdWithLock(@Param("id") id: Long): ScreeningEntity?
 }

--- a/movie/infra/src/main/kotlin/com/example/movie/persistence/screening/repository/ScreeningJpaRepository.kt
+++ b/movie/infra/src/main/kotlin/com/example/movie/persistence/screening/repository/ScreeningJpaRepository.kt
@@ -13,4 +13,8 @@ interface ScreeningJpaRepository : JpaRepository<ScreeningEntity, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT s FROM ScreeningEntity s WHERE s.id = :id")
     fun findByIdWithLock(@Param("id") id: Long): ScreeningEntity?
+
+    @Lock(LockModeType.OPTIMISTIC)
+    @Query("SELECT s FROM ScreeningEntity s WHERE s.id = :id")
+    fun findByIdWithOptimisticLock(@Param("id") id: Long): ScreeningEntity?
 }

--- a/movie/infra/src/main/kotlin/com/example/movie/persistence/screening/repository/ScreeningRepositoryImpl.kt
+++ b/movie/infra/src/main/kotlin/com/example/movie/persistence/screening/repository/ScreeningRepositoryImpl.kt
@@ -2,6 +2,9 @@ package com.example.movie.persistence.screening.repository
 
 import com.example.movie.domain.screening.model.Screening
 import com.example.movie.domain.screening.repository.ScreeningRepository
+import com.example.movie.persistence.screening.model.ScreeningEntity
+import org.springframework.dao.OptimisticLockingFailureException
+import org.springframework.orm.ObjectOptimisticLockingFailureException
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -14,5 +17,28 @@ class ScreeningRepositoryImpl(
 
     override fun findByIdWithLock(id: Long): Screening? {
         return screeningJpaRepository.findByIdWithLock(id)?.toDomain()
+    }
+
+    override fun findByIdWithOptimisticLock(id: Long): Screening? {
+        return screeningJpaRepository.findByIdWithOptimisticLock(id)?.toDomain()
+    }
+
+    override fun save(screening: Screening): Screening {
+        try {
+            val entity = if (screening.id > 0) {
+                val existingEntity = screeningJpaRepository.findByIdWithOptimisticLock(screening.id)
+                    ?: throw IllegalArgumentException("Screening not found (id=${screening.id})")
+
+                existingEntity.updateFromDomain(screening)
+                existingEntity
+            } else {
+                ScreeningEntity.from(screening)
+            }
+
+            val savedEntity = screeningJpaRepository.save(entity)
+            return savedEntity.toDomain()
+        } catch (e: ObjectOptimisticLockingFailureException) {
+            throw OptimisticLockingFailureException("Concurrent modification detected")
+        }
     }
 }

--- a/movie/infra/src/main/kotlin/com/example/movie/persistence/screening/repository/ScreeningRepositoryImpl.kt
+++ b/movie/infra/src/main/kotlin/com/example/movie/persistence/screening/repository/ScreeningRepositoryImpl.kt
@@ -11,4 +11,8 @@ class ScreeningRepositoryImpl(
     override fun findById(id: Long): Screening? {
         return screeningJpaRepository.findById(id).orElse(null)?.toDomain()
     }
+
+    override fun findByIdWithLock(id: Long): Screening? {
+        return screeningJpaRepository.findByIdWithLock(id)?.toDomain()
+    }
 }


### PR DESCRIPTION
### 제목(title)
> 주차와 함께 변경 사항을 요약하여 구성해 주세요.  
> ex: **[1주차] 사용자 로그인 기능 구현**  
#### 예매 api 구현 및 동시성 제어를 위한 락 추가
<br/>  

### 작업 내용  
> 이번 PR에서 진행된 주요 변경 사항을 기술해 주세요.  
>**코드 구조, 핵심 로직** 등에 대해 설명해 주시면 좋습니다. (이미지 첨부 가능)  
> ex: `ConcurrentOrderService`에 동시 주문 요청 처리 기능 추가   
-  4b30ff48436b3df7cbf945c38407fecb74545c27 예약 api 구현했습니다. 
  - Seat, Reservation 을 추가했습니다. 예약은 Reservation에 추가되는 항목으로 관리됩니다.
- 3e2e968d37eaa4d88dafb51745f7c809932c1b5a 비관적 락 적용했습니다.
  - screening_id, seat_id를 기준으로 락이 잡히며, 다른 시간대 동일 seat_id의 예약의 경우 가능합니다. 같은 시간, 동일 seat_id의 경우 예약에 실패합니다.
- b3cd83f2bb974e8b1ac7c0121bb04ace15e54bd5 낙관적 락 적용했습니다.
  - screening에 version 정보 추가했습니다.
  - screening 조회시에 optimistic lock 옵션으로 조회하도록 했습니다.
  - 예매 동작 수행시 remainingSeatCount를 수정해 save 호출시 jpa 통해 version 정보가 관리되고 이를 낙관적 락에 사용할 수 있도록 했습니다.
  - 3회 재시도하도록 수정했습니다.
- c2b374ecb4a45bab05a77cd7b66e9b745a773b90 aop 기반 분산 락을 구현했습니다. 
  - RedissonClient를 이용하는 aspect와 이를 지정하는 annotation을 추가했습니다.
  - spEL을 이용해 메서드 인자를 이용해 key를 설정하도록 했습니다.
- bc9faaeba4850a08aca4cbee77359ec4aec690fb 함수형 인자 기반 분산 락을 구현했습니다.
  - RedissonClient에 실제 동작을 인자로 받는 확장함수를 추가했습니다.
- 구현에 시간이 소요되어 성능 테스트 및 테스트 코드 작성은 하지 못했습니다.
- 각 커밋 시점에서 ReservationController...Test 로 Lock 동작 확인했습니다.
 
### 발생했던 문제와 해결 과정을 남겨 주세요. 
> ex) **문제 1** - 다수의 사용자가 동시에 같은 리소스를 업데이트할 때 재고 수량이 음수로 내려가는 데이터 불일치 문제 발생  
> **해결 방법 1** - Redis SET 명령어에 NX(Not Exists)와 PX(Expire Time) 옵션을 활용해 락을 설정했습니다. 이유는 ~ 
- **문제 1** 낙관락 구현시 기존 구현에선 Screening 내 수정될 필드가 없어서 version 관리가 제대로 되지 않는 이슈가 있었습니다.
- **해결 방법 1** remainingSeatCount 필드를 추가하고, updateAt, updateBy가 갱신되도록 수정했습니다.
- **문제 2** 영속성 컨텍스트에서 조회하고, 이를 도메인 객체로 만들었습니다. 도메인 객체 수정후 영속성 컨텍스트에 반영할때, 조회했던 객체와 다른 객체라 낙관락에서 사용하는 version 관리가 제대로 되지 않았습니다.
- **해결 방법 2** save 동작에서 id로 조회해 새로 생성된 객체가 아니면, 영속성 컨텍스트에서 가져오고 수정내용을 반영하도록 했습니다.

### 이번 주차에서 고민되었던 지점이나, 어려웠던 점을 알려 주세요.
> 과제를 해결하며 특히 어려웠던 점이나 고민되었던 지점이 있다면 남겨주세요. 
- 낙관락 구현시 Transactional 동작과 재시도를 제어하는 메서드를 분리해야하는 것을 늦게 확인해 구현에 시간이 많이 소요되었습니다.
- 낙관락 구현시 업데이트 되는 값이 없으면 버젼 갱신이 없는 것 확인이 늦어 구현에 시간이 많이 소요되었습니다.
  - 로컬에 서비스를 띄우고 DB값을 보기 전까진 버젼 갱신 확인이 어려웠습니다. 
- 헥사고날 구조를 도입한 것 때문에 계층 분리를 하는 것들이 구현에도, 동작에도 오버헤드로 작용했습니다.

### 리뷰 포인트
> 리뷰어가 특히 의견을 주었으면 하는 부분이 있다면 작성해 주세요.<br/>
> ex) Redis 락 설정 부분의 타임아웃 값이 적절한지 의견을 여쭙고 싶습니다. 
- screening과 seat 기준으로 락을 설정했습니다. 또한 reservation 테이블엔 실제 예약이 생성되면 레코드가 생성되는 구조였습니다. 비즈니스 로직상 reservation은 생성되는 대상이지만, api 구현이나 락 구현에 있어서 이런 디자인이 오히려 문제로 작용한 것 같습니다. screening 생성시에 해당 상영에 대응되는 각 좌석별 reservation들을 미리 생성해, reservation에 락을 걸고 status를 갱신시키는 접근은 어땠을지 궁금합니다.

### 기타 질문
> 추가로 질문하고 싶은 내용이 있다면 남겨주세요.<br/>
> ex) 테스트 환경에서 동시성 테스트를 수행하였고, 모든 케이스를 통과했습니다. 추가할 테스트 시나리오가 있을까요?
- 한 브랜치에서 여러 구현들을 적용하고 이를 테스트하려니 환경 분리하고 관리하면 꽤 많은 자원이 들 것 같은데요, 이런 경우 오히려 브랜치를 이용하는 방법이 더 효율적이지 않은지 의견이 궁금합니다.