### PR TITLE
[4주차] RateLimit 적용, 비관락/Redisson 분산락 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,9 @@ subprojects { // 모든 하위 모듈들에 이 설정을 적용합니다.
 
 		// validation
 		implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+		// Guava Rate Limiter
+		implementation("com.google.guava:guava:31.1-jre")
 	}
 
 	test {

--- a/module-api/src/main/java/org/example/controller/MovieController.java
+++ b/module-api/src/main/java/org/example/controller/MovieController.java
@@ -1,12 +1,14 @@
 package org.example.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.baseresponse.BaseResponse;
 import org.example.dto.request.MoviesFilterRequestDto;
 import org.example.dto.response.PlayingMoviesResponseDto;
+import org.example.exception.RateLimitExceededException;
+import org.example.service.RedisRateLimiterService;
 import org.example.service.movie.MovieService;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -14,15 +16,40 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+import static org.example.baseresponse.BaseResponseStatus.TOO_MANY_REQUEST_ERROR;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
 public class MovieController {
     private final MovieService movieService;
+    private final RedisRateLimiterService redisRateLimiterService;
 
     @GetMapping("/movies/playing")
-    public BaseResponse<List<PlayingMoviesResponseDto>> getPlayingMovies(@ModelAttribute @Validated MoviesFilterRequestDto moviesFilterRequestDto) {
+    public BaseResponse<List<PlayingMoviesResponseDto>> getPlayingMovies(@ModelAttribute @Validated MoviesFilterRequestDto moviesFilterRequestDto, HttpServletRequest request) {
+        String clientIp = getClientIP(request);
+
+        // IP 차단 여부 확인
+        Long allowed = redisRateLimiterService.isAllowed(clientIp);
+        if (allowed == -1) {
+            throw new RateLimitExceededException(TOO_MANY_REQUEST_ERROR);
+        }
+
         List<PlayingMoviesResponseDto> playingMovies = movieService.getPlayingMovies(moviesFilterRequestDto);
         return new BaseResponse<>(playingMovies);
+    }
+
+    private String getClientIP(HttpServletRequest request) {
+        String ip = request.getHeader("X-Forwarded-For");
+        if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("Proxy-Client-IP");
+        }
+        if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("WL-Proxy-Client-IP");
+        }
+        if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getRemoteAddr();
+        }
+        return ip;
     }
 }

--- a/module-api/src/main/java/org/example/controller/MovieController.java
+++ b/module-api/src/main/java/org/example/controller/MovieController.java
@@ -2,6 +2,7 @@ package org.example.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.baseresponse.BaseResponse;
 import org.example.dto.request.MoviesFilterRequestDto;
 import org.example.dto.response.PlayingMoviesResponseDto;
 import org.example.service.movie.MovieService;
@@ -20,8 +21,8 @@ public class MovieController {
     private final MovieService movieService;
 
     @GetMapping("/movies/playing")
-    public ResponseEntity<List<PlayingMoviesResponseDto>> getPlayingMovies(@ModelAttribute @Validated MoviesFilterRequestDto moviesFilterRequestDto) {
+    public BaseResponse<List<PlayingMoviesResponseDto>> getPlayingMovies(@ModelAttribute @Validated MoviesFilterRequestDto moviesFilterRequestDto) {
         List<PlayingMoviesResponseDto> playingMovies = movieService.getPlayingMovies(moviesFilterRequestDto);
-        return ResponseEntity.ok(playingMovies);
+        return new BaseResponse<>(playingMovies);
     }
 }

--- a/module-api/src/main/java/org/example/controller/ReservationController.java
+++ b/module-api/src/main/java/org/example/controller/ReservationController.java
@@ -1,6 +1,8 @@
 package org.example.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.example.baseresponse.BaseResponse;
+import org.example.baseresponse.BaseResponseStatus;
 import org.example.dto.request.ReservationRequestDto;
 import org.example.service.ReservationService;
 import org.springframework.http.ResponseEntity;
@@ -10,15 +12,16 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import static org.example.baseresponse.BaseResponseStatus.SUCCESS;
+
 @RestController
 @RequiredArgsConstructor
 public class ReservationController {
     private final ReservationService reservationService;
 
     @PostMapping("/reservation")
-    public ResponseEntity<String> getPlayingMovies(@RequestBody @Validated ReservationRequestDto reservationRequestDto) {
+    public BaseResponse<BaseResponseStatus> getPlayingMovies(@RequestBody @Validated ReservationRequestDto reservationRequestDto) {
         reservationService.reserveMovie(reservationRequestDto);
-        return ResponseEntity.ok("예약이 완료되었습니다.");
+        return new BaseResponse<>(SUCCESS);
     }
-
 }

--- a/module-api/src/main/java/org/example/dto/request/ReservationRequestDto.java
+++ b/module-api/src/main/java/org/example/dto/request/ReservationRequestDto.java
@@ -8,5 +8,5 @@ import java.util.List;
 public record ReservationRequestDto(
         @NotNull Long usersId,
         @NotNull Long screenScheduleId,
-        @NotNull @Valid List<ReservationSeat> reservationSeats
+        @NotNull @Valid List<ReservationSeatDto> reservationSeats
 ) {}

--- a/module-api/src/main/java/org/example/dto/request/ReservationSeatDto.java
+++ b/module-api/src/main/java/org/example/dto/request/ReservationSeatDto.java
@@ -4,7 +4,7 @@ import org.example.annotaion.ValidEnum;
 import org.example.domain.seat.Col;
 import org.example.domain.seat.Row;
 
-public record ReservationSeat(
+public record ReservationSeatDto(
         @ValidEnum(enumClass = Row.class, message = "올바른 행 이름을 입력해주세요.")
         String row,
         @ValidEnum(enumClass = Col.class, message = "올바른 열 이름을 입력해주세요.")

--- a/module-api/src/main/java/org/example/service/RedisRateLimiterService.java
+++ b/module-api/src/main/java/org/example/service/RedisRateLimiterService.java
@@ -1,0 +1,43 @@
+package org.example.service;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@Slf4j
+@Service
+@AllArgsConstructor
+public class RedisRateLimiterService {
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String LUA_SCRIPT =
+            "local ip = KEYS[1]\n" +
+                    "local blockKey = 'block:' .. ip\n" +
+                    "local requestKey = 'request:' .. ip\n" +
+
+                    "if redis.call('EXISTS', blockKey) == 1 then\n" +
+                    "    return -1\n" +
+                    "end\n" +
+
+                    "local currentCount = tonumber(redis.call('GET', requestKey) or '0')\n" +
+                    "redis.call('SET', requestKey, currentCount) \n" +
+
+                    "if currentCount >= tonumber('50') then\n" +
+                    "    redis.call('SETEX', blockKey, 3600, 'BLOCKED')\n" +
+                    "    redis.call('DEL', requestKey)\n" +
+                    "    return -1\n" +
+                    "end\n" +
+
+                    "currentCount = redis.call('INCR', requestKey)\n" +
+
+                    "return currentCount";
+
+    public Long isAllowed(String ip) {
+        Long result = redisTemplate.execute(RedisScript.of(LUA_SCRIPT, Long.class), Collections.singletonList(ip));
+        return result;
+    }
+}

--- a/module-api/src/main/java/org/example/service/ReservationService.java
+++ b/module-api/src/main/java/org/example/service/ReservationService.java
@@ -3,145 +3,105 @@ package org.example.service;
 import jakarta.persistence.OptimisticLockException;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.example.common.exception.SeatException;
 import org.example.domain.reservation.Reservation;
+import org.example.domain.reservationseat.ReservationSeat;
 import org.example.domain.seat.Col;
 import org.example.domain.seat.Row;
 import org.example.domain.seat.Seat;
-import org.example.dto.ReservedSeats;
+import org.example.dto.SeatsDto;
 import org.example.dto.request.ReservationRequestDto;
-import org.example.dto.request.ReservationSeat;
+import org.example.dto.request.ReservationSeatDto;
+import org.example.exception.SeatException;
 import org.example.repository.ReservationJpaRepository;
+import org.example.repository.ReservationSeatRepository;
 import org.example.repository.ScreenScheduleJpaRepository;
 import org.example.repository.SeatJpaRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 
-import static org.example.common.response.BaseResponseStatus.*;
+import static org.example.baseresponse.BaseResponseStatus.*;
 
 @Slf4j
 @Service
 @AllArgsConstructor
 public class ReservationService {
-    private static final int MAX_SEAT_COUNT = 5;
-
     private final ReservationJpaRepository reservationJpaRepository;
     private final SeatJpaRepository seatJpaRepository;
     private final ScreenScheduleJpaRepository screenScheduleJpaRepository;
+    private final ReservationSeatRepository reservationSeatRepository;
 
     @Transactional
     public void reserveMovie(ReservationRequestDto reservationRequestDto) {
-        validateSeats(reservationRequestDto.reservationSeats());
+        List<SeatsDto> reservationSeats = new ArrayList<>(
+                reservationRequestDto.reservationSeats().stream()
+                        .map(seat -> new SeatsDto(Row.valueOf(seat.row()), Col.valueOf(seat.col())))
+                        .toList()
+        );
 
-        Long screenRoomId = screenScheduleJpaRepository.findScreenRoomIdById(reservationRequestDto.screenScheduleId());
-        validateUserReserveSeats(reservationRequestDto.reservationSeats(), reservationRequestDto.usersId(), reservationRequestDto.screenScheduleId());
+        // 예약하려는 좌석 검증
+        validateSeats(reservationSeats);
 
-        try {
-            List<Seat> seats = new ArrayList<>();
-            for (ReservationSeat reservationSeat : reservationRequestDto.reservationSeats()) {
-                Row row = Row.valueOf(reservationSeat.row());
-                Col col = Col.valueOf(reservationSeat.col());
+        // 사용자가 동일한 상영에 대해 예약한 좌석 검증
+        validateUserReserveSeats(reservationSeats, reservationRequestDto.usersId(), reservationRequestDto.screenScheduleId());
 
-                Seat seat = seatJpaRepository.findSeats(screenRoomId, row, col)
-                        .orElseThrow(() -> new SeatException(UNAVAILABLE_SEAT_ERROR));
+        // 좌석에 락을 걸고 저장할 좌석들 반환
+        List<Seat> seats = validateReservedSeats(reservationRequestDto, reservationSeats);
 
-                seats.add(seat);
-            }
-            saveReservation(reservationRequestDto.usersId(), reservationRequestDto.screenScheduleId(), seats);
-        } catch (OptimisticLockException e) {
-            throw new SeatException(CONCURRENT_RESERVATION_ERROR);
-        }
-    }
-
-    private void validateSeats(List<ReservationSeat> seats) {
-        validateSeatCount(seats);
-        validateContinuousSeats(seats);
-    }
-
-    private void validateSeatCount(List<ReservationSeat> seats) {
-        if (seats.size() > MAX_SEAT_COUNT) {
-            throw new SeatException(MAX_SEATS_EXCEEDED_ERROR);
-        }
-    }
-
-    private void validateContinuousSeats(List<ReservationSeat> seats) {
-        seats.sort(Comparator.comparing(ReservationSeat::col));
-
-        for (int i = 1; i < seats.size(); i++) {
-            ReservationSeat prev = seats.get(i - 1);
-            ReservationSeat current = seats.get(i);
-
-            if (!prev.row().equals(current.row())) {
-                throw new SeatException(SEAT_ROW_DISCONTINUITY_ERROR);
-            }
-
-            int prevCol = Col.valueOf(prev.col()).getColumn();
-            int currentCol = Col.valueOf(current.col()).getColumn();
-            if (currentCol != prevCol + 1) {
-                throw new SeatException(SEAT_COLUMN_DISCONTINUITY_ERROR);
-            }
-        }
-    }
-
-    private void validateUserReserveSeats(List<ReservationSeat> reservationSeats, Long userId, Long screenScheduleId) {
-        List<ReservedSeats> reservedSeatsByUserId = reservationJpaRepository.findReservedSeatByUserIdAndScreenScheduleId(userId, screenScheduleId);
-        if (reservedSeatsByUserId.isEmpty()) {
-            return;
-        }
-
-        isInMaxCount(reservationSeats, reservedSeatsByUserId); // 예약하려는 좌석이 5개 이상인지
-        containsReservedSeat(reservationSeats, reservedSeatsByUserId); // 이미 예약된 좌석과 겹치는지
-        isSameRow(reservationSeats, reservedSeatsByUserId); // 좌석이 같은 행에 있는지
-        isContinuousCol(reservationSeats, reservedSeatsByUserId); // 좌석이 연속된 열인지
-    }
-
-    private void isInMaxCount(List<ReservationSeat> reservationSeats, List<ReservedSeats> reservedSeatsByUserId) {
-        if (reservationSeats.size() + reservedSeatsByUserId.size() > MAX_SEAT_COUNT) {
-            throw new SeatException(MAX_SEATS_EXCEEDED_ERROR);
-        }
-    }
-
-    private void containsReservedSeat(List<ReservationSeat> reservationSeats, List<ReservedSeats> reservedSeatsByUserId) {
-        for (ReservedSeats reservedSeats : reservedSeatsByUserId) {
-            for (ReservationSeat reservationSeat : reservationSeats) {
-                if (reservedSeats.getRow().equals(Row.valueOf(reservationSeat.row()))
-                        && reservedSeats.getCol().equals(Col.valueOf(reservationSeat.col()))) {
-                    throw new SeatException(ALREADY_RESERVED_SEAT_ERROR);
-                }
-            }
-        }
-    }
-
-    private void isSameRow(List<ReservationSeat> reservationSeats, List<ReservedSeats> reservedSeatsByUserId) {
-        Row row = reservedSeatsByUserId.get(0).getRow();
-        for (ReservationSeat reservationSeat : reservationSeats) {
-            if (!row.equals(Row.valueOf(reservationSeat.row()))) {
-                throw new SeatException(SEAT_ROW_DISCONTINUITY_ERROR);
-            }
-        }
-    }
-
-    private void isContinuousCol(List<ReservationSeat> reservationSeats, List<ReservedSeats> reservedSeatsByUserId) {
-        Col reservedCol = reservedSeatsByUserId.get(reservedSeatsByUserId.size() - 1).getCol();
-        Col reservationCol = Col.valueOf(reservationSeats.get(0).col());
-        if (reservationCol.getColumn() != reservedCol.getColumn()+1) {
-            throw new SeatException(SEAT_COLUMN_DISCONTINUITY_ERROR);
-        }
-    }
-
-    private void saveReservation(Long userId, Long screenScheduleId, List<Seat> seats) {
+        // 예약된 좌석인지 검증
         for (Seat seat : seats) {
-            boolean isReserved = reservationJpaRepository.existsByUsersIdAndScreenScheduleIdAndSeatId(userId, screenScheduleId, seat.getId());
+            boolean isReserved = reservationSeatRepository.findReservedSeatBySeatId(reservationRequestDto.screenScheduleId(), seat.getId()).isPresent();
             if (isReserved) {
                 throw new SeatException(ALREADY_RESERVED_SEAT_ERROR);
             }
+        }
 
-            Reservation reservation = Reservation.create(userId, screenScheduleId, seat.getId());
-            reservationJpaRepository.save(reservation);
+        Long reservationId = saveReservation(reservationRequestDto.usersId(), reservationRequestDto.screenScheduleId());
+        saveReservationSeats(seats, reservationId);
+    }
+
+    private void validateSeats(List<SeatsDto> seats) {
+        Seat.validateCountExceeded(seats.size());
+        Seat.validateContinuousSeats(seats);
+    }
+
+    private void validateUserReserveSeats(List<SeatsDto> reservationSeats, Long userId, Long screenScheduleId) {
+        List<SeatsDto> reservedSeats = reservationSeatRepository.findReservedSeatByUserIdAndScreenScheduleId(userId, screenScheduleId);
+        if (reservedSeats.isEmpty()) {
+            return;
+        }
+
+        Seat.validateCountExceeded(reservationSeats.size() + reservedSeats.size()); // 예약하려는 좌석이 5개 이상인지
+        Seat.containsReservedSeat(reservationSeats, reservedSeats); // 이미 예약된 좌석과 겹치는지
+        Seat.isSameRow(reservationSeats, reservedSeats); // 좌석이 같은 행에 있는지
+        Seat.isContinuousCol(reservationSeats, reservedSeats); // 좌석이 연속된 열인지
+    }
+
+    private List<Seat> validateReservedSeats(ReservationRequestDto reservationRequestDto, List<SeatsDto> reservationSeats) {
+        Long screenRoomId = screenScheduleJpaRepository.findScreenRoomIdById(reservationRequestDto.screenScheduleId());
+        List<Seat> seats = new ArrayList<>();
+        for (SeatsDto reservationSeat : reservationSeats) {
+            Seat seat = seatJpaRepository.findSeats(screenRoomId, reservationSeat.getRow(), reservationSeat.getCol())
+                    .orElseThrow(() -> new SeatException(UNAVAILABLE_SEAT_ERROR));
+
+            seats.add(seat);
+        }
+        return seats;
+    }
+
+    private Long saveReservation(Long userId, Long screenScheduleId) {
+        Reservation reservation = Reservation.of(userId, screenScheduleId);
+        Reservation savedReservation = reservationJpaRepository.save(reservation);
+        return savedReservation.getId();
+    }
+
+    private void saveReservationSeats(List<Seat> seats, Long reservationId) {
+        for (Seat seat : seats) {
+            ReservationSeat reservationSeat = ReservationSeat.of(reservationId, seat.getId());
+            reservationSeatRepository.save(reservationSeat);
         }
     }
 }

--- a/module-api/src/main/java/org/example/service/ReservationService.java
+++ b/module-api/src/main/java/org/example/service/ReservationService.java
@@ -51,7 +51,7 @@ public class ReservationService {
 
         // 개별 좌석별 락 키 생성
         List<String> lockKeys = reservationRequestDto.reservationSeats().stream()
-                .map(seat -> "lock:seat:" + screenRoomId + ":" + seat.row() + ":" + seat.col())
+                .map(seat -> "lock:seat:" + reservationRequestDto.screenScheduleId() + ":" + seat.row() + ":" + seat.col())
                 .toList();
 
         // Redisson MultiLock 적용 (여러 개의 좌석을 동시에 보호)

--- a/module-api/src/main/java/org/example/service/ReservationService.java
+++ b/module-api/src/main/java/org/example/service/ReservationService.java
@@ -1,6 +1,5 @@
 package org.example.service;
 
-import jakarta.persistence.OptimisticLockException;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.domain.reservation.Reservation;
@@ -10,20 +9,19 @@ import org.example.domain.seat.Row;
 import org.example.domain.seat.Seat;
 import org.example.dto.SeatsDto;
 import org.example.dto.request.ReservationRequestDto;
-import org.example.dto.request.ReservationSeatDto;
 import org.example.exception.SeatException;
 import org.example.repository.ReservationJpaRepository;
 import org.example.repository.ReservationSeatRepository;
 import org.example.repository.ScreenScheduleJpaRepository;
 import org.example.repository.SeatJpaRepository;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.example.baseresponse.BaseResponseStatus.*;
+import static org.example.baseresponse.BaseResponseStatus.ALREADY_RESERVED_SEAT_ERROR;
+import static org.example.baseresponse.BaseResponseStatus.UNAVAILABLE_SEAT_ERROR;
 
 @Slf4j
 @Service

--- a/module-api/src/main/java/org/example/service/ReservationService.java
+++ b/module-api/src/main/java/org/example/service/ReservationService.java
@@ -1,7 +1,9 @@
 package org.example.service;
 
+import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.config.RedissonLockUtil;
 import org.example.domain.reservation.Reservation;
 import org.example.domain.reservationseat.ReservationSeat;
 import org.example.domain.seat.Col;
@@ -15,7 +17,6 @@ import org.example.repository.ReservationSeatRepository;
 import org.example.repository.ScreenScheduleJpaRepository;
 import org.example.repository.SeatJpaRepository;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,8 +32,8 @@ public class ReservationService {
     private final SeatJpaRepository seatJpaRepository;
     private final ScreenScheduleJpaRepository screenScheduleJpaRepository;
     private final ReservationSeatRepository reservationSeatRepository;
+    private final RedissonLockUtil redissonLockUtil;
 
-    @Transactional
     public void reserveMovie(ReservationRequestDto reservationRequestDto) {
         List<SeatsDto> reservationSeats = new ArrayList<>(
                 reservationRequestDto.reservationSeats().stream()
@@ -40,14 +41,30 @@ public class ReservationService {
                         .toList()
         );
 
+        Long screenRoomId = screenScheduleJpaRepository.findScreenRoomIdById(reservationRequestDto.screenScheduleId());
+
         // 예약하려는 좌석 검증
         validateSeats(reservationSeats);
 
         // 사용자가 동일한 상영에 대해 예약한 좌석 검증
         validateUserReserveSeats(reservationSeats, reservationRequestDto.usersId(), reservationRequestDto.screenScheduleId());
 
+        // 개별 좌석별 락 키 생성
+        List<String> lockKeys = reservationRequestDto.reservationSeats().stream()
+                .map(seat -> "lock:seat:" + screenRoomId + ":" + seat.row() + ":" + seat.col())
+                .toList();
+
+        // Redisson MultiLock 적용 (여러 개의 좌석을 동시에 보호)
+        redissonLockUtil.executeWithMultiLock(lockKeys, 5, 10, () -> {
+            saveReservationWithTransaction(reservationRequestDto, reservationSeats, screenRoomId);
+            return null;
+        });
+    }
+
+    @Transactional
+    public void saveReservationWithTransaction(ReservationRequestDto reservationRequestDto, List<SeatsDto> reservationSeats, Long screenRoomId) {
         // 좌석에 락을 걸고 저장할 좌석들 반환
-        List<Seat> seats = validateReservedSeats(reservationRequestDto, reservationSeats);
+        List<Seat> seats = validateReservedSeats(screenRoomId, reservationSeats);
 
         // 예약된 좌석인지 검증
         for (Seat seat : seats) {
@@ -78,8 +95,7 @@ public class ReservationService {
         Seat.isContinuousCol(reservationSeats, reservedSeats); // 좌석이 연속된 열인지
     }
 
-    private List<Seat> validateReservedSeats(ReservationRequestDto reservationRequestDto, List<SeatsDto> reservationSeats) {
-        Long screenRoomId = screenScheduleJpaRepository.findScreenRoomIdById(reservationRequestDto.screenScheduleId());
+    private List<Seat> validateReservedSeats(Long screenRoomId, List<SeatsDto> reservationSeats) {
         List<Seat> seats = new ArrayList<>();
         for (SeatsDto reservationSeat : reservationSeats) {
             Seat seat = seatJpaRepository.findSeats(screenRoomId, reservationSeat.getRow(), reservationSeat.getCol())

--- a/module-api/src/main/java/org/example/service/movie/FindMovieService.java
+++ b/module-api/src/main/java/org/example/service/movie/FindMovieService.java
@@ -19,10 +19,16 @@ public class FindMovieService {
     private final MovieJpaRepository movieJpaRepository;
 
     @Cacheable(value = "playingMovies",
-            key = "#moviesFilterRequestDto.genre + #moviesFilterRequestDto.playing")
+            key = "(#moviesFilterRequestDto.genre != null ? #moviesFilterRequestDto.genre : 'ALL') " +
+                    "+ (#moviesFilterRequestDto.playing != null ? #moviesFilterRequestDto.playing : false)")
     public FoundMovieScreeningInfoList getPlayingMovies(MoviesFilterRequestDto moviesFilterRequestDto) {
+        Genre genre = null;
+        if (moviesFilterRequestDto.getGenre() != null) {
+            genre = Genre.valueOf(moviesFilterRequestDto.getGenre());
+        }
+
         List<MovieScreeningInfo> movieScreeningInfos
-                = movieJpaRepository.findScreeningInfos(moviesFilterRequestDto.getMovieTitle(), Genre.valueOf(moviesFilterRequestDto.getGenre()), moviesFilterRequestDto.isPlaying());
+                = movieJpaRepository.findScreeningInfos(moviesFilterRequestDto.getMovieTitle(), genre, moviesFilterRequestDto.isPlaying());
         return new FoundMovieScreeningInfoList(movieScreeningInfos);
     }
 }

--- a/module-api/src/main/java/org/example/service/movie/MovieService.java
+++ b/module-api/src/main/java/org/example/service/movie/MovieService.java
@@ -25,9 +25,9 @@ public class MovieService {
     public final RateLimiter rateLimiter;
 
     public List<PlayingMoviesResponseDto> getPlayingMovies(MoviesFilterRequestDto moviesFilterRequestDto) {
-        if (!rateLimiter.tryAcquire()) {
-            throw new RateLimitExceededException(TOO_MANY_REQUEST_ERROR);
-        }
+//        if (!rateLimiter.tryAcquire()) {
+//            throw new RateLimitExceededException(TOO_MANY_REQUEST_ERROR);
+//        }
 
         List<MovieScreeningInfo> movieScreeningInfos =
                 findMovieService.getPlayingMovies(moviesFilterRequestDto).getMovieScreeningInfos()

--- a/module-api/src/main/java/org/example/service/movie/MovieService.java
+++ b/module-api/src/main/java/org/example/service/movie/MovieService.java
@@ -1,5 +1,6 @@
 package org.example.service.movie;
 
+import com.google.common.util.concurrent.RateLimiter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.dto.MovieScreeningInfo;
@@ -7,12 +8,12 @@ import org.example.dto.request.MoviesFilterRequestDto;
 import org.example.dto.response.PlayingMoviesResponseDto;
 import org.example.dto.response.ScreeningInfo;
 import org.example.dto.response.ScreeningTimeInfo;
+import org.example.exception.RateLimitExceededException;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+
+import static org.example.baseresponse.BaseResponseStatus.TOO_MANY_REQUEST_ERROR;
 
 @Slf4j
 @Service
@@ -20,12 +21,21 @@ import java.util.Map;
 public class MovieService {
     private final FindMovieService findMovieService;
 
+    // 초당 2개의 요청을 허용
+    public final RateLimiter rateLimiter;
+
     public List<PlayingMoviesResponseDto> getPlayingMovies(MoviesFilterRequestDto moviesFilterRequestDto) {
+        if (!rateLimiter.tryAcquire()) {
+            throw new RateLimitExceededException(TOO_MANY_REQUEST_ERROR);
+        }
+
         List<MovieScreeningInfo> movieScreeningInfos =
                 findMovieService.getPlayingMovies(moviesFilterRequestDto).getMovieScreeningInfos()
-                .stream()
-                .filter(movieScreeningInfo -> movieScreeningInfo.getTitle().contains(moviesFilterRequestDto.getMovieTitle()))
-                .toList();
+                        .stream()
+                        .filter(movieScreeningInfo ->
+                                Optional.ofNullable(movieScreeningInfo.getTitle()).orElse("")
+                                        .contains(Optional.ofNullable(moviesFilterRequestDto.getMovieTitle()).orElse("")))
+                        .toList();
 
         Map<Long, PlayingMoviesResponseDto> movieInfoMap = new HashMap<>();
 

--- a/module-api/src/main/resources/application.yml
+++ b/module-api/src/main/resources/application.yml
@@ -6,10 +6,10 @@ spring:
     password: ${DATASOURCE_PASSWORD}
 
   jpa:
-    show-sql: true
     properties:
       hibernate:
         format_sql: true
+        show-sql: true
         dialect: org.hibernate.dialect.MySQLDialect
     hibernate:
       ddl-auto: none

--- a/module-api/src/test/java/org/example/ApiApplicationTest.java
+++ b/module-api/src/test/java/org/example/ApiApplicationTest.java
@@ -1,12 +1,58 @@
 package org.example;
 
+import com.google.common.util.concurrent.RateLimiter;
+import org.example.repository.MovieJpaRepository;
+import org.example.service.movie.FindMovieService;
+import org.example.service.movie.MovieService;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
 class ApiApplicationTest {
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private MovieService movieService;
+
+    @Autowired
+    private FindMovieService findMovieService;
+
+    @Autowired
+    private RateLimiter rateLimiter;
+
+    @Autowired
+    private MovieJpaRepository movieJpaRepository;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
     @Test
-    void contextLoads() {
+    void testRateLimiter_BlocksExcessRequests() throws Exception {
+        String url = "http://localhost:" + port + "/movies/playing";
+
+        // 첫 번째 요청
+        ResponseEntity<String> response1 = restTemplate.getForEntity(url, String.class);
+        Assertions.assertEquals(HttpStatus.OK, response1.getStatusCode());
+
+        // 두 번째 요청
+        ResponseEntity<String> response2 = restTemplate.getForEntity(url, String.class);
+        Assertions.assertEquals(HttpStatus.OK, response2.getStatusCode());
+
+        // 세 번째 요청
+        ResponseEntity<String> response3 = restTemplate.getForEntity(url, String.class);
+        Assertions.assertEquals(HttpStatus.TOO_MANY_REQUESTS, response3.getStatusCode());
     }
 }

--- a/module-api/src/test/java/org/example/GuavaRateLimiterTest.java
+++ b/module-api/src/test/java/org/example/GuavaRateLimiterTest.java
@@ -1,0 +1,47 @@
+package org.example;
+
+import com.google.common.util.concurrent.RateLimiter;
+import org.example.service.movie.FindMovieService;
+import org.example.service.movie.MovieService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class GuavaRateLimiterTest {
+    @MockBean
+    private FindMovieService findMovieService;
+
+    private MovieService movieService;
+
+    private RateLimiter rateLimiter;
+
+    @BeforeEach
+    void setUp() throws InterruptedException {
+        MockitoAnnotations.openMocks(this);
+        rateLimiter = RateLimiter.create(2.0); // 초당 2개의 요청을 허용하는 RateLimiter
+        movieService = new MovieService(findMovieService, rateLimiter);
+        Thread.sleep(500);
+    }
+
+    @Test
+    void testRateLimiter_AllowsOnlyTwoRequestsPerSecond() {
+        assertTrue(movieService.rateLimiter.tryAcquire()); // 첫 번째 요청 허용
+        assertTrue(movieService.rateLimiter.tryAcquire()); // 두 번째 요청 허용
+        assertFalse(movieService.rateLimiter.tryAcquire()); // 세 번째 요청 거부
+    }
+
+    @Test
+    void testRateLimiter_AllowsRequestAfterDelay() throws InterruptedException {
+        assertTrue(movieService.rateLimiter.tryAcquire()); // 첫 번째 요청 허용
+        assertTrue(movieService.rateLimiter.tryAcquire()); // 두 번째 요청 허용
+        assertFalse(movieService.rateLimiter.tryAcquire()); // 세 번째 요청 거부
+
+        Thread.sleep(1000); // 1초 후 토큰이 다시 충전됨
+
+        assertTrue(movieService.rateLimiter.tryAcquire()); // 다시 요청 가능
+    }
+}

--- a/module-api/src/test/java/org/example/ReservationConcurrencyTest.java
+++ b/module-api/src/test/java/org/example/ReservationConcurrencyTest.java
@@ -1,9 +1,11 @@
 package org.example;
 
 import org.assertj.core.api.Assertions;
+import org.example.dto.SeatsDto;
 import org.example.dto.request.ReservationRequestDto;
-import org.example.dto.request.ReservationSeat;
+import org.example.dto.request.ReservationSeatDto;
 import org.example.repository.ReservationJpaRepository;
+import org.example.repository.ReservationSeatRepository;
 import org.example.service.ReservationService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,7 +25,7 @@ public class ReservationConcurrencyTest {
     private ReservationService reservationService;
 
     @Autowired
-    private ReservationJpaRepository reservationJpaRepository;
+    private ReservationSeatRepository reservationSeatRepository;
 
     @Test
     void testConcurrentReservation() throws InterruptedException {
@@ -31,11 +33,11 @@ public class ReservationConcurrencyTest {
         ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
         CountDownLatch latch = new CountDownLatch(numberOfThreads);
 
-        List<ReservationSeat> reservationSeats = new ArrayList<>();
-        reservationSeats.add(new ReservationSeat("ROW_A", "COL_1"));
+        List<ReservationSeatDto> reservationSeatDtos = new ArrayList<>();
+        reservationSeatDtos.add(new ReservationSeatDto("ROW_A", "COL_1"));
 
         for (long i = 0; i < numberOfThreads; i++) {
-            ReservationRequestDto reservationRequestDto = new ReservationRequestDto(i, 2L, reservationSeats);
+            ReservationRequestDto reservationRequestDto = new ReservationRequestDto(i, 2L, reservationSeatDtos);
             executorService.execute(() -> {
                 try {
                     reservationService.reserveMovie(reservationRequestDto);
@@ -50,7 +52,7 @@ public class ReservationConcurrencyTest {
         latch.await();
         executorService.shutdown();
 
-        List<Long> reservedSeatByUserId = reservationJpaRepository.findReservedSeatByScreenScheduleId(2L);
-        Assertions.assertThat(reservedSeatByUserId.size()).isEqualTo(1);
+        List<Long> reservedSeats = reservationSeatRepository.findReservedSeatByScreenScheduleId(2L);
+        Assertions.assertThat(reservedSeats.size()).isEqualTo(1);
     }
 }

--- a/module-common/src/main/java/org/example/baseresponse/BaseResponse.java
+++ b/module-common/src/main/java/org/example/baseresponse/BaseResponse.java
@@ -1,10 +1,10 @@
-package org.example.common.response;
+package org.example.baseresponse;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Getter;
 
-import static org.example.common.response.BaseResponseStatus.SUCCESS;
+import static org.example.baseresponse.BaseResponseStatus.SUCCESS;
 
 @Getter
 @JsonPropertyOrder({"code", "status", "message", "result"})

--- a/module-common/src/main/java/org/example/baseresponse/BaseResponseStatus.java
+++ b/module-common/src/main/java/org/example/baseresponse/BaseResponseStatus.java
@@ -1,4 +1,4 @@
-package org.example.common.response;
+package org.example.baseresponse;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/module-common/src/main/java/org/example/baseresponse/BaseResponseStatus.java
+++ b/module-common/src/main/java/org/example/baseresponse/BaseResponseStatus.java
@@ -18,8 +18,8 @@ public enum BaseResponseStatus implements ResponseStatus {
     MAX_SEATS_EXCEEDED_ERROR(5003, HttpStatus.BAD_REQUEST.value(), "최대 예약 가능한 좌석을 초과했습니다."),
     SEAT_ROW_DISCONTINUITY_ERROR(5004, HttpStatus.BAD_REQUEST.value(), "연속된 좌석만 예약할 수 있습니다. 행이 다릅니다."),
     SEAT_COLUMN_DISCONTINUITY_ERROR(5005, HttpStatus.BAD_REQUEST.value(), "연속된 좌석만 예약할 수 있습니다. 열이 연속되지 않았습니다."),
-    ALREADY_RESERVED_SEAT_ERROR(5006, HttpStatus.BAD_REQUEST.value(), "이미 예약된 좌석입니다.");
-
+    ALREADY_RESERVED_SEAT_ERROR(5006, HttpStatus.BAD_REQUEST.value(), "이미 예약된 좌석입니다."),
+    TOO_MANY_REQUEST_ERROR(5007, HttpStatus.TOO_MANY_REQUESTS.value(), "너무 많은 요청이 들어왔습니다. 나중에 다시 시도해주세요.");
 
     private final int code;
     private final int status;

--- a/module-common/src/main/java/org/example/baseresponse/ResponseStatus.java
+++ b/module-common/src/main/java/org/example/baseresponse/ResponseStatus.java
@@ -1,4 +1,4 @@
-package org.example.common.response;
+package org.example.baseresponse;
 
 public interface ResponseStatus {
     int getCode();

--- a/module-common/src/main/java/org/example/baseresponse/error/BaseErrorResponse.java
+++ b/module-common/src/main/java/org/example/baseresponse/error/BaseErrorResponse.java
@@ -1,9 +1,9 @@
-package org.example.common.error;
+package org.example.baseresponse.error;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.example.common.response.ResponseStatus;
+import org.example.baseresponse.ResponseStatus;
 
 @Getter
 @RequiredArgsConstructor

--- a/module-common/src/main/java/org/example/config/RateLimiterConfig.java
+++ b/module-common/src/main/java/org/example/config/RateLimiterConfig.java
@@ -1,0 +1,13 @@
+package org.example.config;
+
+import com.google.common.util.concurrent.RateLimiter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RateLimiterConfig {
+    @Bean
+    public RateLimiter rateLimiter() {
+        return RateLimiter.create(2.0);
+    }
+}

--- a/module-common/src/main/java/org/example/config/RedissonConfig.java
+++ b/module-common/src/main/java/org/example/config/RedissonConfig.java
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class ReddisonConfig {
+public class RedissonConfig {
 
     @Bean
     public RedissonClient redissonClient() {

--- a/module-common/src/main/java/org/example/config/RedissonLockUtil.java
+++ b/module-common/src/main/java/org/example/config/RedissonLockUtil.java
@@ -1,0 +1,47 @@
+package org.example.config;
+
+import lombok.AllArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+@Component
+@AllArgsConstructor
+public class RedissonLockUtil {
+    private final RedissonClient redissonClient;
+
+    /**
+     * 분산락을 적용하여 함수 실행
+     * @param lockKeys 락 키 값 (예: "lock:seat:1:A:5")
+     * @param waitTime 락 대기 시간 (초)
+     * @param leaseTime 락 유지 시간 (초)
+     * @param task 락을 걸고 실행할 함수
+     * @return task 실행 결과
+     */
+    public <T> T executeWithMultiLock(List<String> lockKeys, int waitTime, int leaseTime, Supplier<T> task) {
+        List<RLock> locks = lockKeys.stream()
+                .map(redissonClient::getLock)
+                .toList();
+        try {
+            boolean locked = redissonClient.getMultiLock(locks.toArray(new RLock[0]))
+                    .tryLock(waitTime, leaseTime, TimeUnit.SECONDS);
+            if (!locked) {
+                throw new RuntimeException("락 획득 실패: " + lockKeys);
+            }
+            return task.get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("락 처리 중 인터럽트 발생", e);
+        } finally {
+            for (RLock lock : locks) {
+                if (lock.isLocked() && lock.isHeldByCurrentThread()) {
+                    lock.unlock();
+                }
+            }
+        }
+    }
+}

--- a/module-common/src/main/java/org/example/exception/BaseException.java
+++ b/module-common/src/main/java/org/example/exception/BaseException.java
@@ -1,7 +1,7 @@
-package org.example.common.exception;
+package org.example.exception;
 
 import lombok.Getter;
-import org.example.common.response.ResponseStatus;
+import org.example.baseresponse.ResponseStatus;
 
 @Getter
 public class BaseException extends RuntimeException {

--- a/module-common/src/main/java/org/example/exception/RateLimitExceededException.java
+++ b/module-common/src/main/java/org/example/exception/RateLimitExceededException.java
@@ -1,0 +1,9 @@
+package org.example.exception;
+
+import org.example.baseresponse.ResponseStatus;
+
+public class RateLimitExceededException extends BaseException {
+    public RateLimitExceededException(ResponseStatus exceptionStatus) {
+        super(exceptionStatus);
+    }
+}

--- a/module-common/src/main/java/org/example/exception/SeatException.java
+++ b/module-common/src/main/java/org/example/exception/SeatException.java
@@ -1,6 +1,6 @@
-package org.example.common.exception;
+package org.example.exception;
 
-import org.example.common.response.ResponseStatus;
+import org.example.baseresponse.ResponseStatus;
 
 public class SeatException extends BaseException {
     public SeatException(ResponseStatus exceptionStatus) {

--- a/module-common/src/main/java/org/example/exception/handler/GlobalExceptionHandler.java
+++ b/module-common/src/main/java/org/example/exception/handler/GlobalExceptionHandler.java
@@ -44,6 +44,7 @@ public class GlobalExceptionHandler {
                 .body(errors);
     }
 
+    @ResponseStatus(HttpStatus.TOO_MANY_REQUESTS)
     @ExceptionHandler(RateLimitExceededException.class)
     public BaseErrorResponse handleRateLimitExceeded(RateLimitExceededException ex) {
         return new BaseErrorResponse(ex.getExceptionStatus());

--- a/module-common/src/main/java/org/example/exception/handler/GlobalExceptionHandler.java
+++ b/module-common/src/main/java/org/example/exception/handler/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package org.example.common.handler;
+package org.example.exception.handler;
 
 import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;

--- a/module-common/src/main/java/org/example/exception/handler/GlobalExceptionHandler.java
+++ b/module-common/src/main/java/org/example/exception/handler/GlobalExceptionHandler.java
@@ -1,10 +1,13 @@
 package org.example.exception.handler;
 
 import jakarta.validation.ConstraintViolationException;
+import org.example.baseresponse.error.BaseErrorResponse;
+import org.example.exception.RateLimitExceededException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.HashMap;
@@ -39,5 +42,10 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(errors);
+    }
+
+    @ExceptionHandler(RateLimitExceededException.class)
+    public BaseErrorResponse handleRateLimitExceeded(RateLimitExceededException ex) {
+        return new BaseErrorResponse(ex.getExceptionStatus());
     }
 }

--- a/module-common/src/main/java/org/example/exception/handler/SeatExceptionControllerAdvice.java
+++ b/module-common/src/main/java/org/example/exception/handler/SeatExceptionControllerAdvice.java
@@ -1,8 +1,8 @@
-package org.example.common.handler;
+package org.example.exception.handler;
 
 import lombok.extern.slf4j.Slf4j;
-import org.example.common.error.BaseErrorResponse;
-import org.example.common.exception.SeatException;
+import org.example.baseresponse.error.BaseErrorResponse;
+import org.example.exception.SeatException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;

--- a/module-domain/src/main/generated/org/example/domain/reservationseat/QReservationSeat.java
+++ b/module-domain/src/main/generated/org/example/domain/reservationseat/QReservationSeat.java
@@ -1,4 +1,4 @@
-package org.example.domain.screenRoom;
+package org.example.domain.reservationseat;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
@@ -10,14 +10,14 @@ import com.querydsl.core.types.Path;
 
 
 /**
- * QScreenRoom is a Querydsl query type for ScreenRoom
+ * QReservationSeat is a Querydsl query type for ReservationSeat
  */
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
-public class QScreenRoom extends EntityPathBase<ScreenRoom> {
+public class QReservationSeat extends EntityPathBase<ReservationSeat> {
 
-    private static final long serialVersionUID = -1107225198L;
+    private static final long serialVersionUID = 652325848L;
 
-    public static final QScreenRoom screenRoom = new QScreenRoom("screenRoom");
+    public static final QReservationSeat reservationSeat = new QReservationSeat("reservationSeat");
 
     public final org.example.entity.QBaseEntity _super = new org.example.entity.QBaseEntity(this);
 
@@ -32,21 +32,23 @@ public class QScreenRoom extends EntityPathBase<ScreenRoom> {
     //inherited
     public final DateTimePath<java.time.LocalDateTime> lastModifiedDate = _super.lastModifiedDate;
 
-    public final StringPath name = createString("name");
+    public final NumberPath<Long> reservationId = createNumber("reservationId", Long.class);
+
+    public final NumberPath<Long> seatId = createNumber("seatId", Long.class);
 
     //inherited
     public final StringPath updatedBy = _super.updatedBy;
 
-    public QScreenRoom(String variable) {
-        super(ScreenRoom.class, forVariable(variable));
+    public QReservationSeat(String variable) {
+        super(ReservationSeat.class, forVariable(variable));
     }
 
-    public QScreenRoom(Path<? extends ScreenRoom> path) {
+    public QReservationSeat(Path<? extends ReservationSeat> path) {
         super(path.getType(), path.getMetadata());
     }
 
-    public QScreenRoom(PathMetadata metadata) {
-        super(ScreenRoom.class, metadata);
+    public QReservationSeat(PathMetadata metadata) {
+        super(ReservationSeat.class, metadata);
     }
 
 }

--- a/module-domain/src/main/generated/org/example/domain/screenroom/QScreenRoom.java
+++ b/module-domain/src/main/generated/org/example/domain/screenroom/QScreenRoom.java
@@ -1,4 +1,4 @@
-package org.example.domain.reservation;
+package org.example.domain.screenroom;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
@@ -10,14 +10,14 @@ import com.querydsl.core.types.Path;
 
 
 /**
- * QReservation is a Querydsl query type for Reservation
+ * QScreenRoom is a Querydsl query type for ScreenRoom
  */
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
-public class QReservation extends EntityPathBase<Reservation> {
+public class QScreenRoom extends EntityPathBase<ScreenRoom> {
 
-    private static final long serialVersionUID = -682898258L;
+    private static final long serialVersionUID = -110207566L;
 
-    public static final QReservation reservation = new QReservation("reservation");
+    public static final QScreenRoom screenRoom = new QScreenRoom("screenRoom");
 
     public final org.example.entity.QBaseEntity _super = new org.example.entity.QBaseEntity(this);
 
@@ -32,25 +32,21 @@ public class QReservation extends EntityPathBase<Reservation> {
     //inherited
     public final DateTimePath<java.time.LocalDateTime> lastModifiedDate = _super.lastModifiedDate;
 
-    public final DateTimePath<java.time.LocalDateTime> reserveTime = createDateTime("reserveTime", java.time.LocalDateTime.class);
-
-    public final NumberPath<Long> screenScheduleId = createNumber("screenScheduleId", Long.class);
+    public final StringPath name = createString("name");
 
     //inherited
     public final StringPath updatedBy = _super.updatedBy;
 
-    public final NumberPath<Long> usersId = createNumber("usersId", Long.class);
-
-    public QReservation(String variable) {
-        super(Reservation.class, forVariable(variable));
+    public QScreenRoom(String variable) {
+        super(ScreenRoom.class, forVariable(variable));
     }
 
-    public QReservation(Path<? extends Reservation> path) {
+    public QScreenRoom(Path<? extends ScreenRoom> path) {
         super(path.getType(), path.getMetadata());
     }
 
-    public QReservation(PathMetadata metadata) {
-        super(Reservation.class, metadata);
+    public QScreenRoom(PathMetadata metadata) {
+        super(ScreenRoom.class, metadata);
     }
 
 }

--- a/module-domain/src/main/generated/org/example/domain/screenschedule/QScreenSchedule.java
+++ b/module-domain/src/main/generated/org/example/domain/screenschedule/QScreenSchedule.java
@@ -1,4 +1,4 @@
-package org.example.domain.screenSchedule;
+package org.example.domain.screenschedule;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
@@ -15,7 +15,7 @@ import com.querydsl.core.types.Path;
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
 public class QScreenSchedule extends EntityPathBase<ScreenSchedule> {
 
-    private static final long serialVersionUID = 943941266L;
+    private static final long serialVersionUID = 2121698994L;
 
     public static final QScreenSchedule screenSchedule = new QScreenSchedule("screenSchedule");
 

--- a/module-domain/src/main/java/org/example/domain/reservation/Reservation.java
+++ b/module-domain/src/main/java/org/example/domain/reservation/Reservation.java
@@ -29,21 +29,16 @@ public class Reservation extends BaseEntity {
     @Column(nullable = false)
     private Long screenScheduleId;
 
-    @Column(nullable = false)
-    private Long seatId;
-
     @Builder
-    public Reservation(Long usersId, Long screenScheduleId, Long seatId) {
+    public Reservation(Long usersId, Long screenScheduleId) {
         this.usersId = usersId;
         this.screenScheduleId = screenScheduleId;
-        this.seatId = seatId;
     }
 
-    public static Reservation create(Long usersId, Long screenScheduleId, Long seatId) {
+    public static Reservation of(Long usersId, Long screenScheduleId) {
         return Reservation.builder()
                 .usersId(usersId)
                 .screenScheduleId(screenScheduleId)
-                .seatId(seatId)
                 .build();
     }
 }

--- a/module-domain/src/main/java/org/example/domain/reservationseat/ReservationSeat.java
+++ b/module-domain/src/main/java/org/example/domain/reservationseat/ReservationSeat.java
@@ -1,0 +1,38 @@
+package org.example.domain.reservationseat;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.domain.reservation.Reservation;
+import org.example.entity.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReservationSeat extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "reservation_seat_id", nullable = false)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long reservationId;
+
+    @Column(nullable = false)
+    private Long seatId;
+
+    @Builder
+    public ReservationSeat(Long reservationId, Long seatId) {
+        this.reservationId = reservationId;
+        this.seatId = seatId;
+    }
+
+    public static ReservationSeat of(Long reservationId, Long seatId) {
+        return ReservationSeat.builder()
+                .reservationId(reservationId)
+                .seatId(seatId)
+                .build();
+    }
+}

--- a/module-domain/src/main/java/org/example/domain/screenroom/ScreenRoom.java
+++ b/module-domain/src/main/java/org/example/domain/screenroom/ScreenRoom.java
@@ -1,4 +1,4 @@
-package org.example.domain.screenRoom;
+package org.example.domain.screenroom;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/module-domain/src/main/java/org/example/domain/screenschedule/ScreenSchedule.java
+++ b/module-domain/src/main/java/org/example/domain/screenschedule/ScreenSchedule.java
@@ -1,4 +1,4 @@
-package org.example.domain.screenSchedule;
+package org.example.domain.screenschedule;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/module-domain/src/main/java/org/example/domain/seat/Seat.java
+++ b/module-domain/src/main/java/org/example/domain/seat/Seat.java
@@ -4,12 +4,24 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.domain.reservationseat.ReservationSeat;
+import org.example.dto.SeatsDto;
 import org.example.entity.BaseEntity;
+import org.example.exception.SeatException;
+
+import java.util.Comparator;
+import java.util.List;
+
+import static org.example.baseresponse.BaseResponseStatus.*;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Slf4j
 public class Seat extends BaseEntity {
+    private static final int MAX_SEAT_COUNT = 5;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "seat_id", nullable = false)
@@ -25,4 +37,57 @@ public class Seat extends BaseEntity {
 
     @Column(nullable = false)
     private Long screenRoomId;
+
+    public static void validateCountExceeded(int seatSize) {
+        if (seatSize > MAX_SEAT_COUNT) {
+            throw new SeatException(MAX_SEATS_EXCEEDED_ERROR);
+        }
+    }
+
+    public static void validateContinuousSeats(List<SeatsDto> seats) {
+        seats.sort(Comparator.comparing(seat -> seat.getCol().getColumn()));
+
+        for (int i = 1; i < seats.size(); i++) {
+            SeatsDto prev = seats.get(i - 1);
+            SeatsDto current = seats.get(i);
+
+            if (!prev.getRow().getRow().equals(current.getRow().getRow())) {
+                throw new SeatException(SEAT_ROW_DISCONTINUITY_ERROR);
+            }
+
+            int prevCol = prev.getCol().getColumn();
+            int currentCol = current.getCol().getColumn();
+            if (currentCol != prevCol + 1) {
+                throw new SeatException(SEAT_COLUMN_DISCONTINUITY_ERROR);
+            }
+        }
+    }
+
+    public static void containsReservedSeat(List<SeatsDto> reservationSeats, List<SeatsDto> seatsDtoByUserId) {
+        for (SeatsDto seatsDto : seatsDtoByUserId) {
+            for (SeatsDto reservationSeat : reservationSeats) {
+                if (seatsDto.getRow().equals(reservationSeat.getRow())
+                        && seatsDto.getCol().equals(reservationSeat.getCol())) {
+                    throw new SeatException(ALREADY_RESERVED_SEAT_ERROR);
+                }
+            }
+        }
+    }
+
+    public static void isSameRow(List<SeatsDto> reservationSeats, List<SeatsDto> seatsDtoByUserId) {
+        Row row = seatsDtoByUserId.get(0).getRow();
+        for (SeatsDto reservationSeat : reservationSeats) {
+            if (!row.equals(reservationSeat.getRow())) {
+                throw new SeatException(SEAT_ROW_DISCONTINUITY_ERROR);
+            }
+        }
+    }
+
+    public static void isContinuousCol(List<SeatsDto> reservationSeats, List<SeatsDto> seatsDtoByUserId) {
+        Col reservedCol = seatsDtoByUserId.get(seatsDtoByUserId.size() - 1).getCol();
+        Col reservationCol = reservationSeats.get(0).getCol();
+        if (reservationCol.getColumn() != reservedCol.getColumn()+1) {
+            throw new SeatException(SEAT_COLUMN_DISCONTINUITY_ERROR);
+        }
+    }
 }

--- a/module-domain/src/main/java/org/example/dto/SeatsDto.java
+++ b/module-domain/src/main/java/org/example/dto/SeatsDto.java
@@ -7,7 +7,7 @@ import org.example.domain.seat.Row;
 
 @Getter
 @AllArgsConstructor
-public class ReservedSeats {
+public class SeatsDto {
     private Row row;
     private Col col;
 }

--- a/module-domain/src/main/java/org/example/repository/ReservationJpaRepository.java
+++ b/module-domain/src/main/java/org/example/repository/ReservationJpaRepository.java
@@ -1,14 +1,7 @@
 package org.example.repository;
 
 import org.example.domain.reservation.Reservation;
-import org.example.dto.SeatsDto;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.util.List;
 
 public interface ReservationJpaRepository extends JpaRepository<Reservation, Long> {
-    @Query("select r.id from Reservation r where r.screenScheduleId=:screenScheduleId")
-    Long findIdByScreenScheduleId(@Param("screenScheduleId") Long screenScheduleId);
 }

--- a/module-domain/src/main/java/org/example/repository/ReservationJpaRepository.java
+++ b/module-domain/src/main/java/org/example/repository/ReservationJpaRepository.java
@@ -1,7 +1,7 @@
 package org.example.repository;
 
 import org.example.domain.reservation.Reservation;
-import org.example.dto.ReservedSeats;
+import org.example.dto.SeatsDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,16 +9,6 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface ReservationJpaRepository extends JpaRepository<Reservation, Long> {
-    @Query("select new org.example.dto.ReservedSeats(s.row, s.col) " +
-            "from Reservation r join Seat s on r.seatId=s.id " +
-            "where r.usersId=:userId and r.screenScheduleId=:screenScheduleId")
-    List<ReservedSeats> findReservedSeatByUserIdAndScreenScheduleId(@Param("userId") Long userId, @Param("screenScheduleId") Long screenScheduleId);
-
-    @Query("select s.id " +
-            "from Reservation r join Seat s on r.seatId=s.id " +
-            "where r.screenScheduleId=:screenScheduleId")
-    List<Long> findReservedSeatByScreenScheduleId(@Param("screenScheduleId") Long screenScheduleId);
-
-
-    boolean existsByUsersIdAndScreenScheduleIdAndSeatId(Long userId, Long screenScheduleId, Long seatId);
+    @Query("select r.id from Reservation r where r.screenScheduleId=:screenScheduleId")
+    Long findIdByScreenScheduleId(@Param("screenScheduleId") Long screenScheduleId);
 }

--- a/module-domain/src/main/java/org/example/repository/ReservationSeatRepository.java
+++ b/module-domain/src/main/java/org/example/repository/ReservationSeatRepository.java
@@ -26,7 +26,7 @@ public interface ReservationSeatRepository extends JpaRepository<ReservationSeat
             "where r.screenScheduleId=:screenScheduleId")
     List<Long> findReservedSeatByScreenScheduleId(@Param("screenScheduleId") Long screenScheduleId);
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
+//    @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select rs from ReservationSeat rs join Reservation r on rs.reservationId=r.id " +
             "where r.screenScheduleId=:screenScheduleId and rs.seatId = :seatId")
     Optional<ReservationSeat> findReservedSeatBySeatId(@Param("screenScheduleId") Long screenScheduleId, @Param("seatId") Long seatId);

--- a/module-domain/src/main/java/org/example/repository/ReservationSeatRepository.java
+++ b/module-domain/src/main/java/org/example/repository/ReservationSeatRepository.java
@@ -1,0 +1,33 @@
+package org.example.repository;
+
+import jakarta.persistence.LockModeType;
+import org.example.domain.reservationseat.ReservationSeat;
+import org.example.dto.SeatsDto;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ReservationSeatRepository extends JpaRepository<ReservationSeat, Long> {
+    @Query("select new org.example.dto.SeatsDto(s.row, s.col) " +
+            "from ReservationSeat rs " +
+            "join Seat s on rs.seatId=s.id " +
+            "join Reservation r on rs.reservationId = r.id " +
+            "where r.usersId=:userId and r.screenScheduleId=:screenScheduleId")
+    List<SeatsDto> findReservedSeatByUserIdAndScreenScheduleId(@Param("userId") Long userId, @Param("screenScheduleId") Long screenScheduleId);
+
+    @Query("select rs.id " +
+            "from ReservationSeat rs " +
+            "join Seat s on rs.seatId=s.id " +
+            "join Reservation r on rs.reservationId = r.id " +
+            "where r.screenScheduleId=:screenScheduleId")
+    List<Long> findReservedSeatByScreenScheduleId(@Param("screenScheduleId") Long screenScheduleId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select rs from ReservationSeat rs join Reservation r on rs.reservationId=r.id " +
+            "where r.screenScheduleId=:screenScheduleId and rs.seatId = :seatId")
+    Optional<ReservationSeat> findReservedSeatBySeatId(@Param("screenScheduleId") Long screenScheduleId, @Param("seatId") Long seatId);
+}

--- a/module-domain/src/main/java/org/example/repository/ScreenScheduleJpaRepository.java
+++ b/module-domain/src/main/java/org/example/repository/ScreenScheduleJpaRepository.java
@@ -1,6 +1,6 @@
 package org.example.repository;
 
-import org.example.domain.screenSchedule.ScreenSchedule;
+import org.example.domain.screenschedule.ScreenSchedule;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;

--- a/module-domain/src/main/java/org/example/repository/SeatJpaRepository.java
+++ b/module-domain/src/main/java/org/example/repository/SeatJpaRepository.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 public interface SeatJpaRepository extends JpaRepository<Seat, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select s from Seat s where s.screenRoomId=:screenRoomId and s.row=:row and s.col=:col " +
-            "and not exists (select 1 from Reservation r where r.seatId = s.id)")
+            "and not exists (select 1 from ReservationSeat rs where rs.seatId = s.id)")
     Optional<Seat> findSeats(@Param("screenRoomId")Long screenRoomId,
                               @Param("row") Row row,
                               @Param("col") Col col);

--- a/module-domain/src/main/java/org/example/repository/SeatJpaRepository.java
+++ b/module-domain/src/main/java/org/example/repository/SeatJpaRepository.java
@@ -1,20 +1,16 @@
 package org.example.repository;
 
-import jakarta.persistence.LockModeType;
 import org.example.domain.seat.Col;
 import org.example.domain.seat.Row;
 import org.example.domain.seat.Seat;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface SeatJpaRepository extends JpaRepository<Seat, Long> {
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select s from Seat s where s.screenRoomId=:screenRoomId and s.row=:row and s.col=:col " +
-            "and not exists (select 1 from ReservationSeat rs where rs.seatId = s.id)")
+    @Query("select s from Seat s where s.screenRoomId=:screenRoomId and s.row=:row and s.col=:col")
     Optional<Seat> findSeats(@Param("screenRoomId")Long screenRoomId,
                               @Param("row") Row row,
                               @Param("col") Col col);


### PR DESCRIPTION
# [4주차] RateLimit 적용, 비관락/Redisson 분산락 적용

<br/>  

## 작업 내용  

### 비관락 구현 
Seat 테이블에 좌석 데이터를 넣고, Seat 테이블에서 좌석을 조회할 때 락을 걸었습니다. 
그리고 ReservationSeat과 Reservation 테이블에 예약 정보를 저장했습니다. 
첫 번째 트랜잭션이 커밋된 후 락이 풀리면 그 다음 트랜잭션이 좌석에 대한 락을 얻게 되고, ReservationSeat 테이블에 좌석이 예약되어 있는지 조회할 때 락을 걸었습니다.

### 함수형 분산락 구현
Redisson MultiLock을 사용해서 모든 좌석의 락을 한꺼번에 획득해야 예약을 진행할 수 있도록 하였습니다.
MultiLock을 적용하기 위해 좌석 별로 락 키를 생성했습니다.

### Guava RateLimiter
Guava RateLimiter를 사용해서 초당 2개의 요청만 허용하도록 구현했습니다.

### Redisson RateLimiter
조회 API 에 Redisson RateLimit 을 적용하기 위해 1분 내 50회 이상 요청 시 1시간 동안 해당 IP 를 차단하는 Lua script를 작성해서 구현했습니다.


## 발생했던 문제와 해결 과정을 남겨 주세요. 
-  **문제 1** - Seat 테이블에만 비관락을 적용했을 때 동시성 제어가 성공하지 않는 문제 발생
-  **해결 방법 1** - ReservationSeat 테이블에도 락을 걸어서 해결했습니다. 트랜잭션 격리 수준 REPEATABLE READ은 트랜잭션이 읽은 데이터를 다른 트랜잭션이 수정하더라도 동일한 결과를 반환할 것을 보장하기 때문입니다. 따라서 트랜잭션이 시작되었을 때 ReservationSeat 데이터를 유지하기 때문에 첫 번째 트랜잭션이 ReservationSeat 테이블에 예약 좌석 데이터를 추가하더라도 다른 트랜잭션들은 알 수 없었던 것입니다. ReservationSeat 테이블에 락을 걸어줌으로써 ReservationSeat 테이블의 최신 데이터를 받아올 수 있게 되었습니다.

## 이번 주차에서 고민되었던 지점이나, 어려웠던 점을 알려 주세요.
> 과제를 해결하며 특히 어려웠던 점이나 고민되었던 지점이 있다면 남겨주세요. 
-  
-  
-    

## 리뷰 포인트
> 리뷰어가 특히 의견을 주었으면 하는 부분이 있다면 작성해 주세요.<br/>
> ex) Redis 락 설정 부분의 타임아웃 값이 적절한지 의견을 여쭙고 싶습니다. 
-  
-
-
-  

### 기타 질문
> 추가로 질문하고 싶은 내용이 있다면 남겨주세요.<br/>
> ex) 테스트 환경에서 동시성 테스트를 수행하였고, 모든 케이스를 통과했습니다. 추가할 테스트 시나리오가 있을까요?
-
-


