### PR TITLE
[5주차] rate limit 적용

### DIFF
--- a/module-app/src/main/java/module/config/AppRedisConfig.java
+++ b/module-app/src/main/java/module/config/AppRedisConfig.java
@@ -1,0 +1,24 @@
+package module.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.redisson.spring.data.connection.RedissonConnectionFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class AppRedisConfig {
+
+	@Bean
+	StringRedisTemplate stringRedisTemplate( RedisConnectionFactory connectionFactory) {
+		return new StringRedisTemplate(connectionFactory);
+	}
+
+}

--- a/module-app/src/main/java/module/config/ratelimit/RateLimitWith.java
+++ b/module-app/src/main/java/module/config/ratelimit/RateLimitWith.java
@@ -1,0 +1,16 @@
+package module.config.ratelimit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import module.config.ratelimit.limiters.RateLimiter;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RateLimitWith {
+	Class<? extends RateLimiter> rateLimiter();
+	boolean postProcess() default false;
+	boolean preProcess() default true;
+}

--- a/module-app/src/main/java/module/config/ratelimit/RateLimiterAop.java
+++ b/module-app/src/main/java/module/config/ratelimit/RateLimiterAop.java
@@ -1,0 +1,56 @@
+package module.config.ratelimit;
+
+import java.lang.reflect.Method;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import lombok.RequiredArgsConstructor;
+import module.config.ratelimit.limiters.RateLimiter;
+import module.config.ratelimit.limiters.RateLimiterFactory;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class RateLimiterAop {
+
+	private final RateLimiterFactory rateLimiterFactory;
+
+	@Around("@annotation(module.config.ratelimit.RateLimitWith)")
+	public Object rateLimiter(final ProceedingJoinPoint joinPoint) throws Throwable {
+		MethodSignature signature = (MethodSignature)joinPoint.getSignature();
+		Method method = signature.getMethod();
+
+		// 설정된 RateLimiter 조회
+		RateLimitWith rateLimitWith = method.getAnnotation(RateLimitWith.class);
+
+		// HttpServletRequest 조회 및 캐싱
+		ServletRequestAttributes attributes =
+			(ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+		ContentCachingRequestWrapper wrappedRequest = new ContentCachingRequestWrapper(attributes.getRequest());
+
+		RateLimiter rateLimiter = rateLimiterFactory.getRateLimiter(rateLimitWith.rateLimiter());
+
+		if(rateLimitWith.preProcess()){
+			if(!rateLimiter.preCheck(joinPoint.getArgs(), wrappedRequest)){
+				return false;
+			}
+		}
+
+		Object result = joinPoint.proceed();
+
+		ContentCachingResponseWrapper wrappedResponse = new ContentCachingResponseWrapper(attributes.getResponse());
+		if(rateLimitWith.postProcess()){
+			rateLimiter.postCheck(joinPoint.getArgs(), wrappedResponse);
+		}
+
+		return result;
+	}
+}

--- a/module-app/src/main/java/module/config/ratelimit/limiters/RateLimiter.java
+++ b/module-app/src/main/java/module/config/ratelimit/limiters/RateLimiter.java
@@ -1,0 +1,9 @@
+package module.config.ratelimit.limiters;
+
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+public interface RateLimiter {
+	boolean preCheck(Object[] args, ContentCachingRequestWrapper request);
+	default void postCheck(Object[] args, ContentCachingResponseWrapper response){}
+}

--- a/module-app/src/main/java/module/config/ratelimit/limiters/RateLimiterFactory.java
+++ b/module-app/src/main/java/module/config/ratelimit/limiters/RateLimiterFactory.java
@@ -1,0 +1,18 @@
+package module.config.ratelimit.limiters;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RateLimiterFactory {
+
+	private final ApplicationContext applicationContext;
+
+	public RateLimiter getRateLimiter(Class<? extends RateLimiter> T){
+		return applicationContext.getBean(T);
+	}
+
+}

--- a/module-app/src/main/java/module/config/ratelimit/limiters/ShowingSearchRateLimiter.java
+++ b/module-app/src/main/java/module/config/ratelimit/limiters/ShowingSearchRateLimiter.java
@@ -1,89 +1,72 @@
 package module.config.ratelimit.limiters;
 
-import java.util.concurrent.TimeUnit;
+import java.util.Collections;
 
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.util.concurrent.RateLimiter;
-
 import exception.showing.TooManyRequestException;
+import lombok.RequiredArgsConstructor;
 
 @Component
+@RequiredArgsConstructor
 public class ShowingSearchRateLimiter implements module.config.ratelimit.limiters.RateLimiter {
 
-	private static final double TOKEN_PER_SECOND = 2;
-	private static final int LIMIT_PER_MINUTE = 50;
+	private static final String LIMIT_PER_SECOND = "2";
+	private static final String LIMIT_PER_MINUTE = "50";
+	private static final DefaultRedisScript<Boolean> LUA_SCRIPT = new DefaultRedisScript(
+		"""
+			local prefix = KEYS[1]
+			local ip = ARGV[1]
+			local LIMIT_PER_SECOND = tonumber(ARGV[2])
+			local LIMIT_PER_MINUTE = tonumber(ARGV[3])
+			
+			local blocked_ip_key = prefix .. ':BlockedIp:' .. ip
+			local request_counter_key = prefix .. ':PerMinuteRequestCounter:' .. ip
+			local per_second_counter_key = prefix .. ':PerSecondRequestCounter:' .. ip
+			
+			if redis.call('EXISTS', blocked_ip_key) == 1 then 
+				return false 
+			end
+			
+			local per_second_count = redis.call('INCR', per_second_counter_key)
+			if per_second_count == 1 then 
+				redis.call('EXPIRE', per_second_counter_key, 1) end
+			if per_second_count > LIMIT_PER_SECOND then
+				return false 
+			end
+			
+			local current_count = redis.call('INCR', request_counter_key)
+			if current_count == 1 then 
+				redis.call('EXPIRE', request_counter_key, 60) 
+			end
+			if current_count > LIMIT_PER_MINUTE then
+			   redis.call('SET', blocked_ip_key, 1)
+			   redis.call('EXPIRE', blocked_ip_key, 3600)
+			   return false
+			end
+			
+			return true
+		""", Boolean.class);
 
-	private final Cache<String, Boolean> blockedIp = CacheBuilder.newBuilder()
-		.expireAfterWrite(1, TimeUnit.HOURS)
-		.build();
-
-	private final Cache<String, Integer> requestCount = CacheBuilder.newBuilder()
-		.expireAfterWrite(1, TimeUnit.MINUTES)
-		.build();
-
-	private final Cache<String, com.google.common.util.concurrent.RateLimiter> ipRateLimiter = CacheBuilder.newBuilder()
-		.expireAfterAccess(1, TimeUnit.MINUTES)
-		.build();
+	private final StringRedisTemplate redisTemplate;
+	private final String KEY_PREFIX = "hanghaeho:showingSearch";
 
 	@Override
 	public boolean preCheck(Object[] args, ContentCachingRequestWrapper request){
 		String ip = request.getRemoteAddr();
-		increaseRequestCount(ip);
-		return isAllowed(ip);
-	}
+		boolean isAllowed = Boolean.TRUE.equals(redisTemplate.execute(
+			LUA_SCRIPT,
+			Collections.singletonList(KEY_PREFIX),
+			ip, LIMIT_PER_SECOND, LIMIT_PER_MINUTE
+		));
 
-	public boolean isAllowed(String ip){
-		int count = requestCount.getIfPresent(ip);
-		System.out.println(count + "회 요청");
-
-		if(count > LIMIT_PER_MINUTE){
-			addBlock(ip);
-			throw new TooManyRequestException();
-		}
-
-		if(isBlocked(ip)){
-			throw new TooManyRequestException();
-		}
-
-		RateLimiter rateLimiter = getRateLimiter(ip);
-		if(!rateLimiter.tryAcquire()){
+		if(!isAllowed){
 			throw new TooManyRequestException();
 		}
 
 		return true;
-	}
-
-	public RateLimiter getRateLimiter(String ip){
-		RateLimiter rateLimiter = ipRateLimiter.getIfPresent(ip);
-
-		if(rateLimiter == null){
-			rateLimiter = com.google.common.util.concurrent.RateLimiter.create(TOKEN_PER_SECOND);
-			ipRateLimiter.put(ip,rateLimiter);
-		}
-
-		return rateLimiter;
-	}
-
-	public void increaseRequestCount(String ip){
-		Integer count = requestCount.getIfPresent(ip);
-
-		if(count == null) {
-			count = 0;
-		}
-
-		// count 증가
-		requestCount.put(ip, ++count);
-	}
-
-	public boolean isBlocked(String ip) {
-		return blockedIp.getIfPresent(ip) != null;
-	}
-
-	public void addBlock(String ip) {
-		blockedIp.put(ip, true);
 	}
 }

--- a/module-app/src/main/java/module/config/ratelimit/limiters/ShowingSearchRateLimiter.java
+++ b/module-app/src/main/java/module/config/ratelimit/limiters/ShowingSearchRateLimiter.java
@@ -1,0 +1,89 @@
+package module.config.ratelimit.limiters;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.util.concurrent.RateLimiter;
+
+import exception.showing.TooManyRequestException;
+
+@Component
+public class ShowingSearchRateLimiter implements module.config.ratelimit.limiters.RateLimiter {
+
+	private static final double TOKEN_PER_SECOND = 2;
+	private static final int LIMIT_PER_MINUTE = 50;
+
+	private final Cache<String, Boolean> blockedIp = CacheBuilder.newBuilder()
+		.expireAfterWrite(1, TimeUnit.HOURS)
+		.build();
+
+	private final Cache<String, Integer> requestCount = CacheBuilder.newBuilder()
+		.expireAfterWrite(1, TimeUnit.MINUTES)
+		.build();
+
+	private final Cache<String, com.google.common.util.concurrent.RateLimiter> ipRateLimiter = CacheBuilder.newBuilder()
+		.expireAfterAccess(1, TimeUnit.MINUTES)
+		.build();
+
+	@Override
+	public boolean preCheck(Object[] args, ContentCachingRequestWrapper request){
+		String ip = request.getRemoteAddr();
+		increaseRequestCount(ip);
+		return isAllowed(ip);
+	}
+
+	public boolean isAllowed(String ip){
+		int count = requestCount.getIfPresent(ip);
+		System.out.println(count + "회 요청");
+
+		if(count > LIMIT_PER_MINUTE){
+			addBlock(ip);
+			throw new TooManyRequestException();
+		}
+
+		if(isBlocked(ip)){
+			throw new TooManyRequestException();
+		}
+
+		RateLimiter rateLimiter = getRateLimiter(ip);
+		if(!rateLimiter.tryAcquire()){
+			throw new TooManyRequestException();
+		}
+
+		return true;
+	}
+
+	public RateLimiter getRateLimiter(String ip){
+		RateLimiter rateLimiter = ipRateLimiter.getIfPresent(ip);
+
+		if(rateLimiter == null){
+			rateLimiter = com.google.common.util.concurrent.RateLimiter.create(TOKEN_PER_SECOND);
+			ipRateLimiter.put(ip,rateLimiter);
+		}
+
+		return rateLimiter;
+	}
+
+	public void increaseRequestCount(String ip){
+		Integer count = requestCount.getIfPresent(ip);
+
+		if(count == null) {
+			count = 0;
+		}
+
+		// count 증가
+		requestCount.put(ip, ++count);
+	}
+
+	public boolean isBlocked(String ip) {
+		return blockedIp.getIfPresent(ip) != null;
+	}
+
+	public void addBlock(String ip) {
+		blockedIp.put(ip, true);
+	}
+}

--- a/module-app/src/main/java/module/config/ratelimit/limiters/TicketReservationRateLimiter.java
+++ b/module-app/src/main/java/module/config/ratelimit/limiters/TicketReservationRateLimiter.java
@@ -1,14 +1,10 @@
 package module.config.ratelimit.limiters;
 
-import java.util.concurrent.TimeUnit;
-
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 import org.springframework.web.util.ContentCachingResponseWrapper;
-
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 
 import dto.ticket.TicketReservationRequest;
 import exception.ticket.NoReservationInfoException;
@@ -19,14 +15,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class TicketReservationRateLimiter implements RateLimiter {
 
-	private final Cache<String, Boolean> blockedUser = CacheBuilder.newBuilder()
-		.expireAfterWrite(5, TimeUnit.MINUTES)
-		.build();
+	private final String KEY_PREFIX = "hanghaeho:ticket_reservation_complete:";
+	private final RedisTemplate<String, String> redisTemplate;
 
 	@Override
 	public boolean preCheck(Object[] args, ContentCachingRequestWrapper request) {
 		TicketReservationRequest ticketReservationRequest = getTicketReservationRequest(args);
-
 		Long showingId = ticketReservationRequest.getShowingId();
 		String username = ticketReservationRequest.getUsername();
 
@@ -52,12 +46,13 @@ public class TicketReservationRateLimiter implements RateLimiter {
 	}
 
 	public boolean isBlocked(String user, Long showingId) {
-		return blockedUser.getIfPresent(blockKeyFormatter(user, showingId)) != null;
+		String key = keyFormatter(user, showingId);
+		return redisTemplate.opsForValue().get(key) != null;
 	}
 
 	public void addBlock(String username, Long showingId) {
-		String key = blockKeyFormatter(username, showingId);
-		blockedUser.put(key, true);
+		String key = keyFormatter(username, showingId);
+		redisTemplate.opsForValue().set(key, "complete", 300000);
 	}
 
 	public TicketReservationRequest getTicketReservationRequest(Object[] args){
@@ -69,7 +64,7 @@ public class TicketReservationRateLimiter implements RateLimiter {
 		throw new NoReservationInfoException();
 	}
 
-	public String blockKeyFormatter(String username, Long showingId){
-		return username + "|" + showingId;
+	public String keyFormatter(String username, Long showingId){
+		return KEY_PREFIX + username + ":" + showingId;
 	}
 }

--- a/module-app/src/main/java/module/config/ratelimit/limiters/TicketReservationRateLimiter.java
+++ b/module-app/src/main/java/module/config/ratelimit/limiters/TicketReservationRateLimiter.java
@@ -1,0 +1,75 @@
+package module.config.ratelimit.limiters;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+import dto.ticket.TicketReservationRequest;
+import exception.ticket.NoReservationInfoException;
+import exception.ticket.TwoManyReservationRequestException;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class TicketReservationRateLimiter implements RateLimiter {
+
+	private final Cache<String, Boolean> blockedUser = CacheBuilder.newBuilder()
+		.expireAfterWrite(5, TimeUnit.MINUTES)
+		.build();
+
+	@Override
+	public boolean preCheck(Object[] args, ContentCachingRequestWrapper request) {
+		TicketReservationRequest ticketReservationRequest = getTicketReservationRequest(args);
+
+		Long showingId = ticketReservationRequest.getShowingId();
+		String username = ticketReservationRequest.getUsername();
+
+		if(isBlocked(username,showingId)){
+			throw new TwoManyReservationRequestException();
+		} else {
+			return true;
+		}
+	}
+
+	@Override
+	public void postCheck(Object[] args, ContentCachingResponseWrapper response) {
+		if(response.getStatus() != HttpStatus.OK.value()){
+			return;
+		}
+
+		TicketReservationRequest ticketReservationRequest = getTicketReservationRequest(args);
+
+		Long showingId = ticketReservationRequest.getShowingId();
+		String username = ticketReservationRequest.getUsername();
+
+		addBlock(username, showingId);
+	}
+
+	public boolean isBlocked(String user, Long showingId) {
+		return blockedUser.getIfPresent(blockKeyFormatter(user, showingId)) != null;
+	}
+
+	public void addBlock(String username, Long showingId) {
+		String key = blockKeyFormatter(username, showingId);
+		blockedUser.put(key, true);
+	}
+
+	public TicketReservationRequest getTicketReservationRequest(Object[] args){
+		for(Object o : args){
+			if(o instanceof TicketReservationRequest){
+				return (TicketReservationRequest) o;
+			}
+		}
+		throw new NoReservationInfoException();
+	}
+
+	public String blockKeyFormatter(String username, Long showingId){
+		return username + "|" + showingId;
+	}
+}

--- a/module-app/src/main/java/module/controller/ShowingController.java
+++ b/module-app/src/main/java/module/controller/ShowingController.java
@@ -14,6 +14,8 @@ import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
+import module.config.ratelimit.limiters.ShowingSearchRateLimiter;
+import module.config.ratelimit.RateLimitWith;
 import module.service.showing.ShowingService;
 
 @RestController
@@ -24,6 +26,7 @@ public class ShowingController {
 	private final ShowingService showingService;
 
 	@GetMapping("/all")
+	@RateLimitWith(rateLimiter = ShowingSearchRateLimiter.class)
 	public ResponseEntity<List<MovieShowingResponse>> getTodayShowing(
 		@Valid @Size(max = 10, message = "제목 최대 길이는 255자 이내 입니다.")
 		@Nullable @RequestParam String title,

--- a/module-app/src/main/java/module/controller/TicketController.java
+++ b/module-app/src/main/java/module/controller/TicketController.java
@@ -17,6 +17,8 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import module.config.ratelimit.RateLimitWith;
+import module.config.ratelimit.limiters.TicketReservationRateLimiter;
 import module.service.ticket.TicketService;
 
 @Slf4j
@@ -43,6 +45,7 @@ public class TicketController {
 	}
 
 	@PostMapping(value = "/reservation")
+	@RateLimitWith(rateLimiter = TicketReservationRateLimiter.class, postProcess = true)
 	public ResponseEntity<String> reservation(
 		@RequestBody TicketReservationRequest request
 	) {

--- a/module-app/src/main/java/module/controller/TicketController.java
+++ b/module-app/src/main/java/module/controller/TicketController.java
@@ -49,6 +49,6 @@ public class TicketController {
 		Long showingId = request.getShowingId();
 		String username = request.getUsername();
 		List<TicketDTO> ticketList = request.getTicketList();
-		return ResponseEntity.ok(ticketService.reservationWithFunctional(showingId, username, ticketList));
+		return ResponseEntity.ok(ticketService.reservation(showingId, username, ticketList));
 	}
 }

--- a/module-app/src/main/java/module/exception/ControllerAdvice.java
+++ b/module-app/src/main/java/module/exception/ControllerAdvice.java
@@ -9,11 +9,13 @@ import org.springframework.web.method.annotation.HandlerMethodValidationExceptio
 
 import exception.common.TryLockFailedException;
 import exception.showing.ShowingNotFoundException;
+import exception.showing.TooManyRequestException;
 import exception.ticket.InvalidAgeForMovieException;
 import exception.ticket.InvalidSeatConditionException;
 import exception.ticket.InvalidTicketException;
 import exception.ticket.NotOnSaleTicketException;
 import exception.ticket.TooManyReservationException;
+import exception.ticket.TwoManyReservationRequestException;
 import exception.user.UserNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 
@@ -81,6 +83,20 @@ public class ControllerAdvice {
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	protected ResponseEntity<String> tryLockFailedException(TryLockFailedException e){
 		return ResponseEntity.status(HttpStatus.NO_CONTENT)
+			.body(e.getMessage());
+	}
+
+	@ExceptionHandler(TooManyRequestException.class)
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	protected ResponseEntity<String> tooManyRequestException(TooManyRequestException e){
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+			.body(e.getMessage());
+	}
+
+	@ExceptionHandler(TwoManyReservationRequestException.class)
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	protected ResponseEntity<String> tooManyReservationRequestException(TwoManyReservationRequestException e){
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
 			.body(e.getMessage());
 	}
 }

--- a/module-app/src/test/java/module/controller/ShowingControllerTest.java
+++ b/module-app/src/test/java/module/controller/ShowingControllerTest.java
@@ -1,0 +1,59 @@
+package module.controller;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class ShowingControllerTest {
+
+	private final MockMvc mockMvc;
+
+	@Autowired
+	public ShowingControllerTest(MockMvc mockMvc) {
+		this.mockMvc = mockMvc;
+	}
+
+	@Test
+	public void 의존성주입() {
+		assertThat(mockMvc).isNotNull();
+	}
+
+	@Test
+	public void 리미터_51번째_조회() throws Exception {
+		String reqURI = "/api/v1/showings/all?title=말할 수 없는 비밀&genreId=2";
+		for (int i = 0; i < 50; i++) {
+			mockMvc.perform(get(reqURI))
+				.andExpect(status().is(HttpStatus.OK.value()));
+			Thread.sleep(500);
+		}
+		mockMvc.perform(get(reqURI))
+			.andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
+	}
+
+	@Test
+	public void 리미터_초당3회() throws Exception {
+		String reqURI = "/api/v1/showings/all?title=말할 수 없는 비밀&genreId=2";
+		IntStream.range(0,2).parallel()
+			.forEach(i->{
+				try {
+					mockMvc.perform(get(reqURI))
+						.andExpect(status().is(HttpStatus.OK.value()));
+				} catch (Exception e) {
+					throw new RuntimeException(e);
+				}
+			});
+		mockMvc.perform(get(reqURI))
+			.andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
+	}
+}

--- a/module-app/src/test/java/module/controller/TicketControllerTest.java
+++ b/module-app/src/test/java/module/controller/TicketControllerTest.java
@@ -1,33 +1,49 @@
 package module.controller;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.Rollback;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.RequestBuilder;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import dto.ticket.TicketResponse;
 
 @SpringBootTest
-@Rollback
+@AutoConfigureMockMvc
 public class TicketControllerTest {
 
 	private final TicketController ticketController;
+	private final MockMvc mockMvc;
+	private final ObjectMapper objectMapper;
 
 	@Autowired
-	public TicketControllerTest(TicketController ticketController) {
+	public TicketControllerTest(TicketController ticketController, MockMvc mockMvc, ObjectMapper objectMapper) {
 		this.ticketController = ticketController;
+		this.mockMvc = mockMvc;
+		this.objectMapper = objectMapper;
 	}
 
 	@Test
 	@DisplayName("[조회] - 기능")
-	public void getAllTicketTest(){
+	public void getAllTicketTest() {
 		//given
 		Long showingId = 7760L;
 
@@ -39,4 +55,34 @@ public class TicketControllerTest {
 		assertThat(allTicket.getBody().size()).isEqualTo(25);
 	}
 
+
+	@Test
+	@DisplayName("limiter - continuous request with same showing")
+	public void 연속두번() throws Exception {
+		// given
+		// 요청 본문 데이터 생성
+		Map<String, Object> requestBody = new HashMap<>();
+		requestBody.put("username", "dbdb1114");
+		requestBody.put("showingId", 9501);
+
+		// ticketList 구성
+		Map<String, Object> ticket = new HashMap<>();
+		ticket.put("ticketId", 58575);
+		requestBody.put("ticketList", Collections.singletonList(ticket));
+
+		// json 문자열로 변환
+		String jsonRequest = objectMapper.writeValueAsString(requestBody);
+
+		// when
+		mockMvc.perform(post("/api/v1/ticket/reservation")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonRequest))
+			.andExpect(status().is(HttpStatus.OK.value()));
+
+		// then
+		mockMvc.perform(post("/api/v1/ticket/reservation")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonRequest))
+			.andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
+	}
 }

--- a/module-core/src/main/java/exception/showing/TooManyRequestException.java
+++ b/module-core/src/main/java/exception/showing/TooManyRequestException.java
@@ -1,0 +1,9 @@
+package exception.showing;
+
+public class TooManyRequestException extends RuntimeException{
+	private static final String DEFAULT_MESSAGE = "요청을 너무 많이 보냈습니다.";
+	public TooManyRequestException() {
+		super(DEFAULT_MESSAGE);
+	}
+
+}

--- a/module-core/src/main/java/exception/ticket/NoReservationInfoException.java
+++ b/module-core/src/main/java/exception/ticket/NoReservationInfoException.java
@@ -1,0 +1,8 @@
+package exception.ticket;
+
+public class NoReservationInfoException extends RuntimeException{
+	private static final String DEFAULT_MESSAGE = "예매정보가 없습니다.";
+	public NoReservationInfoException() {
+		super(DEFAULT_MESSAGE);
+	}
+}

--- a/module-core/src/main/java/exception/ticket/TwoManyReservationRequestException.java
+++ b/module-core/src/main/java/exception/ticket/TwoManyReservationRequestException.java
@@ -1,0 +1,8 @@
+package exception.ticket;
+
+public class TwoManyReservationRequestException extends RuntimeException {
+	private static final String DEFAULT_MESSAGE = "5분 뒤 다시 시도해주세요";
+	public TwoManyReservationRequestException() {
+		super(DEFAULT_MESSAGE);
+	}
+}

--- a/module-service/src/main/java/module/lock/aop/AopForTransaction.java
+++ b/module-service/src/main/java/module/lock/aop/AopForTransaction.java
@@ -10,7 +10,6 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component
 public class AopForTransaction {
-    private AopForTransaction() {}
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     protected Object proceed(final ProceedingJoinPoint joinPoint) throws Throwable {
         return joinPoint.proceed();

--- a/module-service/src/main/java/module/lock/aop/DistributedLockAop.java
+++ b/module-service/src/main/java/module/lock/aop/DistributedLockAop.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
@@ -29,7 +30,7 @@ public class DistributedLockAop {
 
 	@Around("@annotation(module.lock.aop.DistributedLock)")
 	public Object lock(final ProceedingJoinPoint joinPoint) throws Throwable {
-		MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+		MethodSignature signature = (MethodSignature)joinPoint.getSignature();
 		Method method = signature.getMethod();
 		DistributedLock distributedLock = method.getAnnotation(DistributedLock.class);
 
@@ -39,14 +40,7 @@ public class DistributedLockAop {
 
 		// Lock 대상이 여러 개일 경우를 대비하여
 		// Collection이나 Array로 변환하여 Lock 점유
-		Object[] keysArr;
-		if(keys instanceof Collection<?>){
-			keysArr = ((Collection<?>)keys).toArray();
-		} else if( keys.getClass().isArray() ){
-			keysArr = (Object[]) keys;
-		} else {
-			keysArr = new Object[] {keys};
-		}
+		Object[] keysArr = convertToArray(keys);
 
 		// key 배열만큼 락 생성
 		List<RLock> lockList = Arrays.stream(keysArr)
@@ -54,45 +48,58 @@ public class DistributedLockAop {
 			.map(key -> redissonClient.getLock(REDISSON_LOCK_PREFIX + keyPrefix + key))
 			.toList();
 
-		try{
+		try {
 			// 락 점유 하나라도 점유 실패 시 TryLockFailedException
-			boolean allAvailable = true;
-			for (RLock lock : lockList) {
-				try{
-					if(!lock.tryLock(distributedLock.waitTime(), distributedLock.leaseTime(),distributedLock.timeUnit())){
-						allAvailable = false;
-						break;
-					}
-				} catch (InterruptedException e){
-					allAvailable = false;
-					break;
-				}
-			}
+			boolean allAvailable = acquireLock(lockList, distributedLock.waitTime(), distributedLock.leaseTime(),
+				distributedLock.timeUnit());
 
-			// 배열내 모든 락이 점유 실패
-			if(!allAvailable){
-				// 순차적으로 락을 해제하도록 변경
-				for (RLock lock : lockList) {
-					if (lock.isHeldByCurrentThread()) {
-						lock.unlock();
-					}
-				}
+			// 배열내 모든 락이 점유 실패시
+			// 점유한 락 해제
+			if (!allAvailable) {
+				leaseAllLock(lockList);
 				throw new TryLockFailedException();
 			}
 
 			return aopForTransaction.proceed(joinPoint);
 		} finally {
 			// 메소드 종료 후 모든 락 점유 해제
-			lockList.forEach(lock -> {
-				if (lock.isHeldByCurrentThread()) {
-					try {
-						lock.unlock();
-					} catch (IllegalMonitorStateException e) {
-						log.warn("Lock was already released: {}", lock.getName());
-					}
-				}
-			});
+			leaseAllLock(lockList);
 		}
 
+	}
+
+	private void leaseAllLock(List<RLock> lockList) {
+		for (RLock lock : lockList) {
+			if (lock.isHeldByCurrentThread()) {
+				try {
+					lock.unlock();
+				} catch (IllegalMonitorStateException e) {
+					log.warn("Lock was already released: {}", lock.getName());
+				}
+			}
+		}
+	}
+
+	private boolean acquireLock(List<RLock> lockList, Long waitTIme, Long leaseTime, TimeUnit timeUnit) {
+		for (RLock lock : lockList) {
+			try {
+				if (!lock.tryLock(waitTIme, leaseTime, timeUnit)) {
+					return false;
+				}
+			} catch (InterruptedException e) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private Object[] convertToArray(Object keys) {
+		if (keys instanceof Collection<?>) {
+			return ((Collection<?>)keys).toArray();
+		} else if (keys.getClass().isArray()) {
+			return (Object[])keys;
+		} else {
+			return new Object[] {keys};
+		}
 	}
 }

--- a/module-service/src/main/java/module/lock/functional/FunctionalForTransaction.java
+++ b/module-service/src/main/java/module/lock/functional/FunctionalForTransaction.java
@@ -9,8 +9,6 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component
 public class FunctionalForTransaction {
-	private FunctionalForTransaction() {}
-
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	protected void run(Runnable runnable){
 		runnable.run();


### PR DESCRIPTION
### [5주차] rate limit 적용
> guava 이용 rate limit 적용했습니다.
> redis 기반 rate limit 적용했습니다.

<br/>  

### 작업 내용  
- rate limit 적용했습니다.

### 발생했던 문제와 해결 과정을 남겨 주세요. 
- lua script가 동작하지 않아서 하루를 통으로 날렸는데, 제가 주석을 잘못된 방식으로 작성해서 안 됐던 것이었습니다.... 

### 이번 주차에서 고민되었던 지점이나, 어려웠던 점을 알려 주세요.
-  rate limit을 적용함에 있어 이 내용을 어떤 관점에서 적용해야 할 지 고민이 많았습니다. 실제로 rate limit이라는 요구사항을 구현해본 게 처음이어서 그랬던 것 같습니다. 

### 리뷰 포인트
- rate limit을 규격화 하여 사용했습니다. preCheck, postCheck를 가지는 Interface를 선언하여 규격화 하고, 이를 ticket 예매와 상영 정보 조회 Rate limit을 별도로 구현했는데 이런 구조가 적절한지 여쭙고 싶습니다. 

### 기타 질문
- 제 생각에 rate limit은 비즈니스 로직 보다는 서버의 안정성과 안전성 면에서 필요한 모듈이라 생각했고, 이런 내용은 여러 api에 구현되야 할 수 있다고 생각했습니다. 그래서 규격할 수 있는 부분과 없는 부분으로 나누어 생각했습니다. 
- 규격화 할 수 있는 부분 : 적용 위치, 적용 방식[ 요청 전처리 및 후처리 ] 
- 규격화 할 수 없는 부분 : api별 rate limit 조건 및 구현 방식 
이런 발상으로 코드를 작성했고, api별 RateLimit 클래스를 작성하고, 어노테이션만 추가하면 각 api에 rate limit을 적용할 수 있도록 설계를 해보았는데 이게 RateLimit을 이런식으로 구현해도 되는 건지, 너무 생각을 많이 해서 조금 오바스럽게 구현한 건 아닌지 여쭤보고 싶습니다.


